### PR TITLE
Release Candidate v5.21.3

### DIFF
--- a/docs/open-api-docs.yaml
+++ b/docs/open-api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The Agent's user-facing API
   description: The user-facing parts of The Agent's API service (excluding system-level endpoints, chat completion, maintenance endpoints, etc.)
-  version: 5.21.2
+  version: 5.21.3
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "the-agent"
-version = "5.21.2"
+version = "5.21.3"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/features/chat/chat_attachment_processor.py
+++ b/src/features/chat/chat_attachment_processor.py
@@ -7,7 +7,7 @@ from langchain_core.documents import Document
 from di.di import DI
 from features.audio.audio_transcriber import AudioTranscriber
 from features.chat.attachment.chat_attachment import ChatAttachment
-from features.chat.supported_files import KNOWN_AUDIO_FORMATS, KNOWN_DOCS_FORMATS, KNOWN_IMAGE_FORMATS
+from features.chat.supported_files import KNOWN_AUDIO_FORMATS, KNOWN_DOCS_FORMATS, KNOWN_IMAGE_FORMATS, resolve_file_type
 from features.documents.document_search import DocumentSearch
 from features.external_tools.intelligence_presets import default_tool_for
 from features.images.computer_vision_analyzer import ComputerVisionAnalyzer
@@ -276,7 +276,8 @@ class ChatAttachmentProcessor:
             contents = stream.read()
 
         # handle audio
-        if attachment.mime_type in KNOWN_AUDIO_FORMATS.values() or attachment.extension in KNOWN_AUDIO_FORMATS.keys():
+        mime_type, extension = resolve_file_type(mime_type = attachment.mime_type, extension = attachment.extension)
+        if mime_type in KNOWN_AUDIO_FORMATS.values() or extension in KNOWN_AUDIO_FORMATS.keys():
             transcriber_tool = self.__di.tool_choice_resolver.require_tool(
                 AudioTranscriber.TRANSCRIBER_TOOL_TYPE,
                 default_tool_for(AudioTranscriber.TRANSCRIBER_TOOL_TYPE),
@@ -288,7 +289,7 @@ class ChatAttachmentProcessor:
             return self.__di.audio_transcriber(
                 job_id = attachment.id,
                 audio_content = contents,
-                extension = attachment.extension,
+                extension = extension,
                 transcriber_tool = transcriber_tool,
                 copywriter_tool = copywriter_tool,
             ).execute()

--- a/src/features/chat/supported_files.py
+++ b/src/features/chat/supported_files.py
@@ -98,6 +98,8 @@ def resolve_file_type(
         tuple[str | None, str | None]: (mime_type, extension)
     """
 
+    mime_type = __mime_type_without_parameters(mime_type)
+
     # 1. try to resolve extension first
     resolved_extension: str | None = extension
     if not resolved_extension and mime_type:
@@ -139,6 +141,7 @@ def detect_image_format(content: bytes) -> str | None:
 
 
 def is_supported_mime_type(mime_type: str | None) -> bool:
+    mime_type = __mime_type_without_parameters(mime_type)
     return bool(mime_type and mime_type in KNOWN_FILE_FORMATS.values())
 
 
@@ -154,6 +157,12 @@ def __extension_from_uri(uri: str | None) -> str | None:
     if not suffix:
         return None
     return suffix.removeprefix(".").lower()
+
+
+def __mime_type_without_parameters(mime_type: str | None) -> str | None:
+    if not mime_type:
+        return None
+    return mime_type.split(";", 1)[0].strip().lower()
 
 
 def __extension_for_mime_type(mime_type: str | None) -> str | None:

--- a/test/features/chat/attachment/test_chat_attachment_service.py
+++ b/test/features/chat/attachment/test_chat_attachment_service.py
@@ -129,6 +129,19 @@ class ChatAttachmentServiceTest(unittest.TestCase):
         self.assertEqual(result.extension, "jpg")
 
     @patch("features.chat.attachment.chat_attachment_service.config")
+    def test_save_with_content_normalizes_parameterized_mime_type(self, mock_config):
+        mock_config.s3_bucket = "the-agent"
+        attachment = replace(self.attachment, mime_type = "audio/ogg; codecs=opus")
+
+        result = self.service.save(attachment, b"audio data")
+
+        self.assertEqual(result.mime_type, "audio/ogg")
+        self.assertEqual(result.extension, "oga")
+        stored_metadata = self.di.attachment_storage.put.call_args.args[0]
+        self.assertEqual(stored_metadata.mime_type, "audio/ogg")
+        self.assertEqual(stored_metadata.extension, "oga")
+
+    @patch("features.chat.attachment.chat_attachment_service.config")
     def test_save_with_content_uses_last_url_for_file_type_fallback(self, mock_config):
         mock_config.public_api_base_url = "http://api.example"
         mock_config.attachment_public_token_ttl_seconds = 600

--- a/test/features/chat/test_chat_attachment_processor.py
+++ b/test/features/chat/test_chat_attachment_processor.py
@@ -27,7 +27,7 @@ from util.functions import digest_md5
 def _make_attachment(
     id: str = "1",
     mime_type: str = "image/png",
-    extension: str = "png",
+    extension: str | None = "png",
     url: str = "http://test.com/file.png",
 ) -> ChatAttachment:
     return ChatAttachment(
@@ -253,6 +253,38 @@ class ChatAttachmentProcessorTest(unittest.TestCase):
         )
         self.mock_di.chat_attachment_service.create_public_url.assert_not_called()
         mock_audio_instance.execute.assert_called_once()
+
+    def test_fetch_text_content_with_parameterized_audio_mime_type(self):
+        audio_attachment = _make_attachment(
+            id = "2",
+            mime_type = "audio/ogg; codecs=opus",
+            extension = None,
+            url = "http://test.com/audio",
+        )
+        self.mock_di.attachment_storage.open.side_effect = lambda attachment: BytesIO(b"audio data")
+        mock_audio_instance = MagicMock()
+        mock_audio_instance.execute.return_value = "Audio transcription"
+        self.mock_di.audio_transcriber.return_value = mock_audio_instance
+        transcriber_tool = MagicMock()
+        copywriter_tool = MagicMock()
+        self.mock_di.tool_choice_resolver.require_tool.side_effect = [transcriber_tool, copywriter_tool]
+
+        resolver = ChatAttachmentProcessor(
+            additional_context = "context",
+            attachment_ids = ["2"],
+            urls = None,
+            di = self.mock_di,
+        )
+        content = resolver.fetch_text_content(audio_attachment)
+
+        self.assertEqual(content, "Audio transcription")
+        self.mock_di.audio_transcriber.assert_called_once_with(
+            job_id = "2",
+            audio_content = b"audio data",
+            extension = "oga",
+            transcriber_tool = transcriber_tool,
+            copywriter_tool = copywriter_tool,
+        )
 
     @requests_mock.Mocker()
     def test_fetch_text_content_with_unsupported_type(self, m: requests_mock.Mocker):

--- a/test/features/chat/test_supported_files.py
+++ b/test/features/chat/test_supported_files.py
@@ -28,6 +28,11 @@ class SupportedFilesTest(unittest.TestCase):
 
         self.assertEqual(result, ("image/jpeg", "jpg"))
 
+    def test_resolve_file_type_normalizes_mime_type_parameters(self):
+        result = resolve_file_type(mime_type = "audio/ogg; codecs=opus")
+
+        self.assertEqual(result, ("audio/ogg", "oga"))
+
     def test_resolve_file_type_keeps_unknown_extension(self):
         result = resolve_file_type(extension = "unknown")
 
@@ -88,6 +93,7 @@ class SupportedFilesTest(unittest.TestCase):
 
     def test_is_supported_mime_type(self):
         self.assertTrue(is_supported_mime_type("image/png"))
+        self.assertTrue(is_supported_mime_type("audio/ogg; codecs=opus"))
         self.assertFalse(is_supported_mime_type("application/x-custom"))
         self.assertFalse(is_supported_mime_type(None))
 


### PR DESCRIPTION
v5.21.3 — The Agent Learns to Read the Signal, Not the Noise 👁️

**A small but important refinement: this version helps The Agent handle file types more cleanly by ignoring extra baggage that doesn’t belong.**

The latest release sharpens one of The Agent’s quieter instincts: understanding what something *really is* without getting distracted by unnecessary metadata.

### What changed
- **The Agent now handles MIME types more cleanly**
- **Extra metadata is excluded**, which helps The Agent focus on the core file type information
- **File-related behavior is now a little more precise and reliable**

It’s a subtle shift beneath the surface — the kind that keeps the machinery in the dark running smoothly.  
Cleaner signals in, better decisions out. ⚙️

More improvements are always moving through the wires.
