### PR TITLE
Release Candidate v5.22.0

### DIFF
--- a/docs/open-api-docs.yaml
+++ b/docs/open-api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The Agent's user-facing API
   description: The user-facing parts of The Agent's API service (excluding system-level endpoints, chat completion, maintenance endpoints, etc.)
-  version: 5.21.3
+  version: 5.22.0
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/design.md
+++ b/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/design.md
@@ -1,0 +1,96 @@
+## Context
+
+`PlatformBotSDK.send_photo()` is the shared Telegram and WhatsApp photo-delivery boundary. `prepare_outgoing_attachment()` currently downloads the source, resizes it when necessary, and stores the resulting bytes internally. A prior change flattened transparent photos over black before resizing, but that helper and call were removed when outbound media moved to internal attachment storage.
+
+Telegram and WhatsApp convert PNGs sent through their photo APIs to JPEG. The application must therefore produce an opaque result before resizing and delivery. File/document mode must continue to preserve the original PNG and its transparency.
+
+The Agent web source defines the relevant palette family: body indigo, burgundy, coral, and warm amber. The accepted previews use fields moved inward from the quadrant centers, a lighter treatment over white, and stronger blur—especially over black.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restore photo-only alpha compositing at the shared platform boundary.
+- Replace the fixed black matte with an adaptive branded mesh for transparent PNGs.
+- Choose white or black from the visible PNG content brightness.
+- Apply the mesh before the existing resize step.
+- Preserve original media for document delivery and the document half of `all` mode.
+- Bound processing cost for large source images and avoid new dependencies.
+
+**Non-Goals:**
+
+- Changing generated or edited image output before it reaches platform delivery.
+- Decorating opaque PNGs, JPEGs, WebP files, document thumbnails, or document delivery.
+- Changing media-mode settings, platform APIs, storage models, or public API docs.
+- Persisting preview assets or introducing user-configurable palettes.
+
+## Decisions
+
+### Prepare only explicit photo delivery
+
+`send_photo()` will explicitly request PNG background preparation from `prepare_outgoing_attachment()`. The default path used by documents and document thumbnails will not request it.
+
+This flag is separate from `should_resize`: document thumbnails currently resize through the same method, so treating every resized attachment as a photo would decorate thumbnails unintentionally. Telegram and WhatsApp still share one preparation path because both platforms exhibit the same JPEG conversion behavior.
+
+### Detect PNG and transparency from decoded bytes
+
+The helper will inspect the downloaded image with Pillow, use the decoded image format rather than the URL or temporary-file suffix, and transform only PNG images with at least one alpha value below 255. Opaque PNGs and other formats return the original path unchanged.
+
+This avoids false decisions from extensionless internal attachment URLs and limits the new behavior to the requested format. Semi-transparent pixels are composited normally rather than thresholded.
+
+### Classify visible content with alpha-weighted luminance
+
+The helper will downsample the RGBA image for bounded analysis, ignore fully transparent pixels, and compute alpha-weighted mean luminance using the existing social-card coefficients:
+
+`(0.299 * red + 0.587 * green + 0.114 * blue) / 255`
+
+A mean above `0.5` is light and selects a white base; otherwise it selects black. Ignoring transparent padding makes the classification describe the PNG contents rather than hidden RGB values. A fully transparent PNG uses the black fallback.
+
+Reusing the formula rather than importing the social-card theme module keeps platform delivery independent of social-card rendering; the shared behavior is the luminance convention, not the feature module.
+
+### Render a low-resolution radial mesh, then composite at source resolution
+
+The opaque background will contain one field for each palette color:
+
+- `#222B4E` — body-gradient indigo
+- `#3F1331` — accent dark burgundy
+- `#FF6C7B` — accent coral
+- `#F9A892` — accent amber
+
+The indigo and burgundy fields use brighter blue and purple brand variants so
+compositing preserves their hue instead of appearing neutral gray or near-black.
+The coral and amber fields keep their canonical palette values.
+
+On a white base, coral and amber use the baseline field strength while indigo and burgundy are 30% stronger. On a black base, coral and amber are 30% weaker while indigo and burgundy are 20% stronger.
+
+Each field starts in a different quadrant. Nominal centers are 30% from their adjacent edges—equivalent to moving 25%-quadrant centers 20% toward the image center—and receive small bounded random offsets. Color-to-quadrant assignment is shuffled so every result contains all four colors without a fixed arrangement.
+
+The mesh is rendered on a bounded working canvas with elongated, randomly rotated Gaussian fields, then upscaled to the source dimensions. The anisotropic falloff creates the accepted smudged effect without erasing separation between the fields. Light-content images use lower field opacity over white. Dark-content images use stronger, wider fields over black so individual shapes remain soft. The original RGBA image is then alpha-composited over the mesh and converted to opaque RGB PNG.
+
+Rendering the mesh at bounded resolution avoids field-generation cost scaling with multi-megapixel inputs while preserving a smooth final background. Direct Gaussian fields also avoid seams from constructing four hard-edged rectangles before blur.
+
+### Transform before resizing and save once
+
+`prepare_outgoing_attachment()` will use the transformed path as input to `resize_file()`. The final opaque or resized bytes are saved once through the existing attachment service. Temporary source, mesh-composited, and resized paths are each passed to the existing idempotent safe-deletion helper; shared paths are harmless.
+
+This ordering enforces Telegram and WhatsApp limits against the actual prepared image and prevents resizing alpha edges before compositing.
+
+### Keep randomization local and testable
+
+Mesh generation will use standard-library random functions behind module-level helpers/constants. Focused tests will patch randomness only where stable preprocessing assertions require it; production sends remain randomized. The visual mesh appearance will be verified through its implementation constants and manual preview rather than brittle pixel-perfect tests.
+
+## Risks / Trade-offs
+
+- [Random results make pixel-exact tests brittle] → Avoid pixel-perfect visual tests and assert only delivery invariants.
+- [Very smooth gradients may band after platform JPEG conversion] → Use oversized overlapping fields and high-quality resizing; avoid visible hard boundaries and excessive synthetic noise that would worsen JPEG size.
+- [Brightness near the threshold may choose an unexpected base] → Keep the established `0.5` threshold and cover boundary behavior explicitly.
+- [Large PNGs add processing time] → Downsample luminance analysis and render blur on a bounded working canvas before upscaling.
+- [The attachment-storage migration removed the prior matte behavior] → Restore preparation at the current internal-attachment boundary and add an ordering regression test.
+
+## Migration Plan
+
+No data migration is required. Deploy the code and tests together; rollback restores the current behavior where transparent PNG photos reach the platform without an application-provided matte.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/proposal.md
+++ b/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Telegram and WhatsApp convert PNG images sent as photos to JPEG, so transparent regions need an intentional background before platform delivery. The previous black-flattening behavior was removed during the attachment-storage migration; restoring that preparation step with an adaptive branded mesh background prevents arbitrary JPEG mattes and produces a better visual result.
+
+## What Changes
+
+- Prepare transparent outgoing PNGs sent as Telegram or WhatsApp photos with an opaque branded mesh-gradient background before photo resizing.
+- Select a white or black base from the visible PNG content brightness, using the existing social-card luminance convention.
+- Generate four heavily blurred, randomized palette fields using colors derived from the Agent web background and accent palette.
+- Preserve original PNGs for file/document delivery, including the document half of `all` media mode.
+- Leave opaque images, non-PNG files, and document delivery unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `platform-photo-delivery`: Prepares transparent PNG photos for deterministic Telegram and WhatsApp JPEG conversion while preserving original file delivery.
+
+### Modified Capabilities
+
+## Impact
+
+- `src/features/integrations/platform_bot_sdk.py`: restore photo-specific preprocessing before the existing resize and attachment-save steps.
+- `src/features/images/`: add focused Pillow utilities for visible-content brightness, mesh rendering, and alpha compositing.
+- `test/features/images/` and `test/features/integrations/`: cover adaptive backgrounds, ordering, media-mode boundaries, and unchanged formats.
+- No database migration, API schema change, or new dependency is expected.

--- a/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/specs/platform-photo-delivery/spec.md
+++ b/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/specs/platform-photo-delivery/spec.md
@@ -1,0 +1,88 @@
+## ADDED Requirements
+
+### Requirement: Adaptive transparent PNG photo background
+The system SHALL composite every transparent or semi-transparent PNG sent through Telegram or WhatsApp photo delivery over an opaque branded mesh background before invoking the platform photo API.
+
+#### Scenario: Transparent PNG with light visible content
+- **WHEN** a PNG containing transparency and light visible content is sent as a Telegram or WhatsApp photo
+- **THEN** the delivered photo SHALL be an opaque image whose branded mesh shades a white base
+
+#### Scenario: Transparent PNG with dark visible content
+- **WHEN** a PNG containing transparency and dark visible content is sent as a Telegram or WhatsApp photo
+- **THEN** the delivered photo SHALL be an opaque image whose branded mesh shades a black base
+
+#### Scenario: Semi-transparent PNG content
+- **WHEN** a PNG contains semi-transparent pixels and is sent as a Telegram or WhatsApp photo
+- **THEN** those pixels SHALL be alpha-composited over the selected mesh background without thresholding their alpha values
+
+#### Scenario: Opaque PNG
+- **WHEN** a PNG without transparent or semi-transparent pixels is sent as a Telegram or WhatsApp photo
+- **THEN** the system SHALL leave its pixel content unchanged by mesh preparation
+
+#### Scenario: Non-PNG photo
+- **WHEN** a JPEG, WebP, or other non-PNG image is sent as a Telegram or WhatsApp photo
+- **THEN** the system SHALL leave its pixel content unchanged by mesh preparation
+
+### Requirement: Visible-content brightness classification
+The system SHALL classify transparent PNG content as light or dark from alpha-weighted visible-pixel luminance using the established `0.299 red + 0.587 green + 0.114 blue` convention and a normalized threshold of `0.5`.
+
+#### Scenario: Transparent padding around light content
+- **WHEN** a transparent PNG has light visible pixels surrounded by fully transparent padding
+- **THEN** the transparent padding SHALL NOT cause the content to be classified as dark
+
+#### Scenario: Transparent padding with hidden RGB values
+- **WHEN** fully transparent pixels contain arbitrary hidden RGB values
+- **THEN** those hidden values SHALL NOT affect the light-or-dark classification
+
+#### Scenario: Fully transparent PNG
+- **WHEN** a PNG has no visible pixels
+- **THEN** the system SHALL use the black-base fallback
+
+### Requirement: Branded randomized mesh composition
+The system SHALL construct each PNG background from all four configured Agent palette colors as heavily blurred fields distributed across the four quadrants with bounded randomized placement and ordering.
+
+#### Scenario: Mesh palette
+- **WHEN** the system prepares a transparent PNG photo
+- **THEN** the background SHALL use the indigo, burgundy, coral, and warm amber palette fields over the selected base
+
+#### Scenario: Inward field placement
+- **WHEN** the system positions the four mesh fields
+- **THEN** their nominal centers SHALL be moved inward from the quadrant centers while remaining distributed across distinct quadrants
+
+#### Scenario: Smooth field transitions
+- **WHEN** the mesh background is rendered
+- **THEN** its fields SHALL overlap with sufficient blur that hard edges, quadrant seams, and distinct circle boundaries are not visible
+
+#### Scenario: Light-base intensity
+- **WHEN** the selected base is white
+- **THEN** the mesh SHALL use restrained color intensity so white remains the dominant background
+
+#### Scenario: Dark-base blur
+- **WHEN** the selected base is black
+- **THEN** the mesh SHALL use stronger blur than the light-base treatment so individual fields remain indistinct
+
+### Requirement: Photo preparation precedes resizing
+The system SHALL apply any required PNG mesh compositing before enforcing the active Telegram or WhatsApp photo size limit.
+
+#### Scenario: Prepared PNG exceeds platform limit
+- **WHEN** mesh compositing produces an image larger than the active platform photo limit
+- **THEN** the system SHALL resize the prepared opaque image before saving and delivering it
+
+#### Scenario: Prepared PNG is within platform limit
+- **WHEN** mesh compositing produces an image within the active platform photo limit
+- **THEN** the system SHALL save and deliver the prepared opaque image without dimension reduction
+
+### Requirement: Original file delivery remains unchanged
+The system SHALL restrict mesh preparation to photo delivery and preserve original media for file/document delivery.
+
+#### Scenario: File media mode
+- **WHEN** a transparent PNG is sent with media mode `file`
+- **THEN** the system SHALL send the original PNG as a document without mesh compositing
+
+#### Scenario: All media mode
+- **WHEN** a transparent PNG is sent with media mode `all`
+- **THEN** the system SHALL send a mesh-composited opaque photo and the original PNG document
+
+#### Scenario: Document thumbnail preparation
+- **WHEN** an image is prepared only as a document thumbnail
+- **THEN** the system SHALL NOT apply the outgoing PNG mesh background to that thumbnail

--- a/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/tasks.md
+++ b/openspec/changes/archive/2026-07-19-add-outgoing-png-mesh-backgrounds/tasks.md
@@ -1,0 +1,26 @@
+## 1. PNG Background Utilities
+
+- [x] 1.1 Restore a focused Pillow bitmap utility module for decoded PNG-format and alpha-channel inspection
+- [x] 1.2 Implement downsampled alpha-weighted visible-content luminance classification with the `0.5` threshold and fully transparent fallback
+- [x] 1.3 Implement bounded-resolution four-field mesh rendering with the Agent palette, inward randomized quadrant placement, and separate light/dark opacity and blur profiles
+- [x] 1.4 Composite transparent and semi-transparent PNG content over the selected mesh and write an opaque RGB PNG while returning opaque PNGs and non-PNG images unchanged
+
+## 2. Platform Photo Delivery
+
+- [x] 2.1 Add an explicit photo-background preparation option to `PlatformBotSDK.prepare_outgoing_attachment()` and enable it only from Telegram and WhatsApp `send_photo()` paths
+- [x] 2.2 Run mesh compositing after download and before `resize_file()`, then save only the final prepared bytes through the existing attachment service
+- [x] 2.3 Clean up source, composited, and resized temporary paths safely when helpers return shared paths
+- [x] 2.4 Preserve original content for file/document delivery, the document side of `all` mode, and document thumbnails
+
+## 3. Regression Tests
+
+- [x] 3.1 Add focused bitmap utility tests for transparent PNG compositing and light/dark classification that ignores transparent padding
+- [x] 3.2 Extend existing platform SDK tests to prove mesh preparation runs before resizing for Telegram and WhatsApp photo sends
+- [x] 3.3 Add media-mode regression coverage proving file delivery, document thumbnails, and the document half of `all` mode retain original content
+
+## 4. Verification
+
+- [x] 4.1 Run `pipenv run ruff check --fix` and `pipenv run python tools/check_spacing.py --fix` on every changed Python file
+- [x] 4.2 Run focused image utility and platform SDK tests with `pipenv run pytest`
+- [x] 4.3 Run the full offline test suite with `pipenv run pytest`
+- [x] 4.4 Run `openspec validate add-outgoing-png-mesh-backgrounds --strict`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "the-agent"
-version = "5.21.3"
+version = "5.22.0"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/features/images/image_bitmap_utils.py
+++ b/src/features/images/image_bitmap_utils.py
@@ -1,0 +1,171 @@
+import io
+import math
+import random
+import tempfile
+from pathlib import Path
+
+from PIL import Image
+
+from features.chat.supported_files import detect_image_format
+from features.images.image_color_utils import relative_luminance
+
+INDIGO = (34, 43, 78)
+BURGUNDY = (63, 19, 49)
+CORAL = (255, 108, 123)
+AMBER = (249, 168, 146)
+MESH_PALETTE = [INDIGO, BURGUNDY, CORAL, AMBER]
+COOL_MESH_COLORS = {INDIGO, BURGUNDY}
+COOL_MESH_COLOR_OVERRIDES = {
+    INDIGO: (42, 69, 176),
+    BURGUNDY: (117, 75, 166),
+}
+
+ANALYSIS_MAX_DIMENSION = 64
+MESH_MAX_DIMENSION = 512
+FIELD_CENTERS = [
+    (0.30, 0.30),
+    (0.70, 0.30),
+    (0.30, 0.70),
+    (0.70, 0.70),
+]
+FIELD_JITTER = 0.04
+LIGHT_FIELD_OPACITY = 36
+DARK_FIELD_OPACITY = 80
+LIGHT_FIELD_SPREAD = (0.27, 0.18)
+DARK_FIELD_SPREAD = (0.34, 0.23)
+
+
+def image_has_transparency(input_path: str) -> bool:
+    with Image.open(input_path) as image:
+        return _image_has_transparency(image)
+
+
+def visible_content_is_light(image: Image.Image) -> bool:
+    sample = image.convert("RGBA")
+    sample.thumbnail(
+        (ANALYSIS_MAX_DIMENSION, ANALYSIS_MAX_DIMENSION),
+        Image.Resampling.LANCZOS,
+    )
+
+    weighted_luminance = 0.0
+    visible_weight = 0.0
+    for red, green, blue, alpha in sample.get_flattened_data():
+        if alpha == 0:
+            continue
+        weight = alpha / 255
+        weighted_luminance += relative_luminance((red, green, blue)) * weight
+        visible_weight += weight
+
+    if visible_weight == 0:
+        return False
+    return weighted_luminance / visible_weight > 0.5
+
+
+def add_outgoing_png_background(input_path: str) -> str:
+    with Path(input_path).open("rb") as file:
+        if detect_image_format(file.read(32)) != "png":
+            return input_path
+
+    with Image.open(input_path) as image:
+        if image.format != "PNG" or not _image_has_transparency(image):
+            return input_path
+
+        source = image.convert("RGBA")
+        is_light = visible_content_is_light(source)
+        background = _render_mesh_background(source.size, is_light)
+        background.alpha_composite(source)
+
+        output = io.BytesIO()
+        background.convert("RGB").save(output, format = "PNG", optimize = True)
+        return _write_temp_file(output.getvalue())
+
+
+def _render_mesh_background(size: tuple[int, int], is_light: bool) -> Image.Image:
+    work_size = _bounded_size(size)
+    base_color = (255, 255, 255, 255) if is_light else (0, 0, 0, 255)
+    spread = LIGHT_FIELD_SPREAD if is_light else DARK_FIELD_SPREAD
+
+    background = Image.new("RGBA", work_size, base_color)
+    colors = MESH_PALETTE.copy()
+    random.shuffle(colors)
+
+    for (center_x, center_y), color in zip(FIELD_CENTERS, colors, strict = True):
+        jittered_x = center_x + random.uniform(-FIELD_JITTER, FIELD_JITTER)
+        jittered_y = center_y + random.uniform(-FIELD_JITTER, FIELD_JITTER)
+        pixel_x = round(work_size[0] * jittered_x)
+        pixel_y = round(work_size[1] * jittered_y)
+        angle = random.uniform(0, math.pi)
+        field_opacity = _field_opacity(color, is_light)
+        mask = _radial_field_mask(
+            work_size,
+            (pixel_x, pixel_y),
+            spread,
+            field_opacity,
+            angle,
+        )
+
+        field_color = COOL_MESH_COLOR_OVERRIDES.get(color, color)
+        field = Image.new("RGBA", work_size, (*field_color, 255))
+        field.putalpha(mask)
+        background.alpha_composite(field)
+
+    if work_size != size:
+        return background.resize(size, Image.Resampling.LANCZOS)
+    return background
+
+
+def _field_opacity(color: tuple[int, int, int], is_light: bool) -> int:
+    if is_light:
+        multiplier = 1.30 if color in COOL_MESH_COLORS else 1.0
+        return round(LIGHT_FIELD_OPACITY * multiplier)
+
+    multiplier = 1.20 if color in COOL_MESH_COLORS else 0.70
+    return round(DARK_FIELD_OPACITY * multiplier * 0.90)
+
+
+def _radial_field_mask(
+    size: tuple[int, int],
+    center: tuple[int, int],
+    spread: tuple[float, float],
+    opacity: int,
+    angle: float,
+) -> Image.Image:
+    width, height = size
+    center_x, center_y = center
+    angle_cos = math.cos(angle)
+    angle_sin = math.sin(angle)
+    pixels = []
+
+    for pixel_y in range(height):
+        offset_y = (pixel_y - center_y) / height
+        for pixel_x in range(width):
+            offset_x = (pixel_x - center_x) / width
+            along = angle_cos * offset_x + angle_sin * offset_y
+            across = -angle_sin * offset_x + angle_cos * offset_y
+            falloff = math.exp(-((along / spread[0]) ** 2 + (across / spread[1]) ** 2))
+            pixels.append(round(opacity * falloff))
+
+    mask = Image.new("L", size)
+    mask.putdata(pixels)
+    return mask
+
+
+def _bounded_size(size: tuple[int, int]) -> tuple[int, int]:
+    width, height = size
+    scale = min(1.0, MESH_MAX_DIMENSION / max(width, height))
+    return max(1, round(width * scale)), max(1, round(height * scale))
+
+
+def _image_has_transparency(image: Image.Image) -> bool:
+    if image.mode in ("RGBA", "LA"):
+        return image.getchannel("A").getextrema()[0] < 255
+    if image.info.get("transparency") is not None:
+        return image.convert("RGBA").getchannel("A").getextrema()[0] < 255
+    return False
+
+
+def _write_temp_file(content: bytes) -> str:
+    with tempfile.NamedTemporaryFile(delete = False, suffix = ".png") as tmp:
+        tmp.write(content)
+        tmp.flush()
+        return tmp.name

--- a/src/features/images/image_color_utils.py
+++ b/src/features/images/image_color_utils.py
@@ -1,0 +1,3 @@
+def relative_luminance(rgb: tuple[int, int, int]) -> float:
+    red, green, blue = rgb
+    return (0.299 * red + 0.587 * green + 0.114 * blue) / 255

--- a/src/features/integrations/platform_bot_sdk.py
+++ b/src/features/integrations/platform_bot_sdk.py
@@ -10,6 +10,7 @@ from di.di import DI
 from features.chat.attachment.chat_attachment import ChatAttachment
 from features.chat.config.chat_config import ChatConfig
 from features.chat.message.chat_message import ChatMessage
+from features.images.image_bitmap_utils import add_outgoing_png_background
 from features.images.image_size_utils import resize_file
 from features.integrations.integration_config import TELEGRAM_MAX_PHOTO_SIZE_BYTES, WHATSAPP_MAX_PHOTO_SIZE_BYTES
 from features.integrations.integrations import is_own_chat
@@ -62,10 +63,10 @@ class PlatformBotSDK:
 
         match self.__di.require_invoker_chat_type():
             case ChatConfigDB.ChatType.telegram:
-                attachment = self.prepare_outgoing_attachment(chat_config, photo_url)
+                attachment = self.prepare_outgoing_attachment(chat_config, photo_url, should_add_png_background = True)
                 return self.__di.telegram_bot_sdk.send_photo(chat_config.external_id, attachment, caption)
             case ChatConfigDB.ChatType.whatsapp:
-                attachment = self.prepare_outgoing_attachment(chat_config, photo_url)
+                attachment = self.prepare_outgoing_attachment(chat_config, photo_url, should_add_png_background = True)
                 return self.__di.whatsapp_bot_sdk.send_photo(chat_config, attachment, caption)
             case _:
                 raise ConfigurationError(f"Unsupported chat type: {self.__di.require_invoker_chat_type()}", UNSUPPORTED_CHAT_TYPE)
@@ -194,6 +195,7 @@ class PlatformBotSDK:
         chat_config: ChatConfig,
         public_url: str,
         should_resize: bool = True,
+        should_add_png_background: bool = False,
     ) -> ChatAttachment:
         # first, we find the max size for photos
         max_size_bytes: int | None = None
@@ -209,6 +211,7 @@ class PlatformBotSDK:
 
         # next, we download the file to a temp location for resizing
         temp_path: str | None = None
+        prepared_path: str | None = None
         resized_path: str | None = None
         try:
             with NamedTemporaryFile(delete = False) as tmp:
@@ -226,7 +229,8 @@ class PlatformBotSDK:
                 log.w(f"Downloaded outbound media is empty '{public_url[:4]}...{public_url[-4:]}'")
                 raise ExternalServiceError("Could not download outbound media", MEDIA_DOWNLOAD_FAILED)
 
-            resized_path = resize_file(temp_path, max_size_bytes)
+            prepared_path = add_outgoing_png_background(temp_path) if should_add_png_background else temp_path
+            resized_path = resize_file(prepared_path, max_size_bytes)
             attachment = self.__di.chat_attachment_service.save(
                 attachment = ChatAttachment(chat_id = chat_config.chat_id, uploader_user_id = self.__di.invoker.id),
                 content = Path(resized_path).read_bytes(),
@@ -235,4 +239,5 @@ class PlatformBotSDK:
             return attachment
         finally:
             delete_file_safe(temp_path)
+            delete_file_safe(prepared_path)
             delete_file_safe(resized_path)

--- a/src/features/social_cards/card_template.py
+++ b/src/features/social_cards/card_template.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from PIL import Image
 
+from features.images.image_color_utils import relative_luminance
 from features.social_cards.card_layout import (
     AVATAR_GAP,
     AVATAR_SIZE,
@@ -74,7 +75,7 @@ def _logo_svg_b64(key: str) -> str:
 def _agent_logo_key(theme: ThemeColors) -> str:
     hex_color = theme.gradient_start.lstrip("#")
     r, g, b = int(hex_color[0:2], 16), int(hex_color[2:4], 16), int(hex_color[4:6], 16)
-    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+    luminance = relative_luminance((r, g, b))
     if luminance < 0.3:
         return "agent_logo_light"
     if luminance > 0.7:

--- a/src/features/social_cards/embedded_post.py
+++ b/src/features/social_cards/embedded_post.py
@@ -3,6 +3,7 @@ import re
 
 from PIL import Image
 
+from features.images.image_color_utils import relative_luminance
 from features.social_cards.card_utils import (
     FONT_NAME,
     b64_image,
@@ -74,8 +75,7 @@ def render_embedded_post(
     # Background rect
     hex_bg = theme.gradient_start.lstrip("#")
     bg_r, bg_g, bg_b = int(hex_bg[0:2], 16), int(hex_bg[2:4], 16), int(hex_bg[4:6], 16)
-    luminance = (0.299 * bg_r + 0.587 * bg_g + 0.114 * bg_b) / 255
-    overlay_fill = "#ffffff" if luminance < 0.5 else "#000000"
+    overlay_fill = "#ffffff" if relative_luminance((bg_r, bg_g, bg_b)) < 0.5 else "#000000"
 
     rect_path = rounded_rect_path(x, y, width, total_h, R, R, R, R)
     content.append(f'<path d="{rect_path}" fill="{overlay_fill}" fill-opacity="{EMBED_OVERLAY_OPACITY}"/>')

--- a/src/features/social_cards/link_preview.py
+++ b/src/features/social_cards/link_preview.py
@@ -5,6 +5,7 @@ from urllib.parse import urlparse
 
 from PIL import Image
 
+from features.images.image_color_utils import relative_luminance
 from features.social_cards.card_layout import PHOTO_CORNER_RADIUS, PHOTO_GAP
 from features.social_cards.card_utils import (
     FONT_NAME,
@@ -143,9 +144,7 @@ def _dominant_color(data: bytes) -> tuple[int, int, int]:
 
 
 def _contrast_text_color(rgb: tuple[int, int, int]) -> str:
-    r, g, b = rgb
-    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-    return "#000000" if luminance > 0.5 else "#ffffff"
+    return "#000000" if relative_luminance(rgb) > 0.5 else "#ffffff"
 
 
 def _contrast_overlay_color(rgb: tuple[int, int, int]) -> str:

--- a/src/features/social_cards/theme.py
+++ b/src/features/social_cards/theme.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from PIL import Image
 
+from features.images.image_color_utils import relative_luminance
 from features.social_cards.brand import BRAND_GRADIENT_END, BRAND_GRADIENT_START
 from util import log
 
@@ -118,9 +119,7 @@ def _derive_gradient_end(rgb: tuple[int, int, int]) -> tuple[int, int, int]:
 
 
 def _contrast_text(rgb: tuple[int, int, int]) -> str:
-    r, g, b = rgb
-    luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
-    return "#000000" if luminance > 0.5 else "#ffffff"
+    return "#000000" if relative_luminance(rgb) > 0.5 else "#ffffff"
 
 
 def _rgb_to_hex(rgb: tuple[int, int, int]) -> str:

--- a/test/features/images/test_image_bitmap_utils.py
+++ b/test/features/images/test_image_bitmap_utils.py
@@ -1,0 +1,65 @@
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from PIL import Image
+
+from features.images.image_bitmap_utils import (
+    add_outgoing_png_background,
+    image_has_transparency,
+    visible_content_is_light,
+)
+
+
+class ImageBitmapUtilsTest(unittest.TestCase):
+
+    def setUp(self):
+        self._temp_files: list[str] = []
+
+    def tearDown(self):
+        for path in self._temp_files:
+            Path(path).unlink(missing_ok = True)
+
+    def _save(self, image: Image.Image, suffix: str, **kwargs) -> str:
+        with tempfile.NamedTemporaryFile(suffix = suffix, delete = False) as file:
+            path = file.name
+        image.save(path, **kwargs)
+        self._temp_files.append(path)
+        return path
+
+    def test_transparent_png_gets_opaque_background(self):
+        image = Image.new("RGBA", (80, 60), color = (0, 0, 0, 0))
+        image.paste((245, 245, 245, 255), (25, 15, 55, 45))
+        path = self._save(image, ".png", format = "PNG")
+
+        with patch("features.images.image_bitmap_utils.random.shuffle"), \
+                patch("features.images.image_bitmap_utils.random.uniform", return_value = 0):
+            result = add_outgoing_png_background(path)
+
+        self._temp_files.append(result)
+        self.assertNotEqual(result, path)
+        self.assertTrue(image_has_transparency(path))
+        with Image.open(result) as prepared:
+            self.assertEqual(prepared.format, "PNG")
+            self.assertEqual(prepared.mode, "RGB")
+            self.assertEqual(prepared.size, image.size)
+
+    def test_opaque_png_and_jpeg_are_unchanged(self):
+        png_path = self._save(Image.new("RGB", (20, 20), color = "white"), ".png", format = "PNG")
+        jpeg_path = self._save(Image.new("RGB", (20, 20), color = "white"), ".jpg", format = "JPEG")
+
+        self.assertEqual(add_outgoing_png_background(png_path), png_path)
+        self.assertEqual(add_outgoing_png_background(jpeg_path), jpeg_path)
+        self.assertFalse(image_has_transparency(png_path))
+
+    def test_visible_content_brightness_ignores_transparent_padding(self):
+        light = Image.new("RGBA", (64, 64), color = (0, 0, 0, 0))
+        light.paste((240, 240, 240, 255), (24, 24, 40, 40))
+        dark = Image.new("RGBA", (64, 64), color = (255, 255, 255, 0))
+        dark.paste((10, 10, 10, 255), (24, 24, 40, 40))
+        transparent = Image.new("RGBA", (64, 64), color = (255, 255, 255, 0))
+
+        self.assertTrue(visible_content_is_light(light))
+        self.assertFalse(visible_content_is_light(dark))
+        self.assertFalse(visible_content_is_light(transparent))

--- a/test/features/images/test_image_color_utils.py
+++ b/test/features/images/test_image_color_utils.py
@@ -1,0 +1,18 @@
+import unittest
+
+from features.images.image_color_utils import relative_luminance
+
+
+class ImageColorUtilsTest(unittest.TestCase):
+
+    def test_relative_luminance_extremes(self):
+        self.assertEqual(relative_luminance((0, 0, 0)), 0)
+        self.assertEqual(relative_luminance((255, 255, 255)), 1)
+
+    def test_relative_luminance_weights_channels(self):
+        self.assertAlmostEqual(relative_luminance((255, 0, 0)), 0.299)
+        self.assertAlmostEqual(relative_luminance((0, 255, 0)), 0.587)
+        self.assertAlmostEqual(relative_luminance((0, 0, 255)), 0.114)
+
+    def test_relative_luminance_returns_normalized_value(self):
+        self.assertAlmostEqual(relative_luminance((128, 128, 128)), 128 / 255)

--- a/test/features/integrations/test_platform_bot_sdk.py
+++ b/test/features/integrations/test_platform_bot_sdk.py
@@ -85,19 +85,46 @@ class PlatformBotSDKTest(unittest.TestCase):
 
     def test_send_photo_resizes_and_uploads(self):
         di = _make_di()
+        prepared_path = _make_temp_file(b"prepared")
         resized_path = _make_temp_file(b"resized")
         sdk = PlatformBotSDK(di = di)
         with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
                 patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
             mock_get.return_value = _mock_response(body = b"x" * (6 * 1024 * 1024))
+            mock_prepare.return_value = prepared_path
             mock_resize.return_value = resized_path
             result = sdk.send_photo(chat_id = 1, photo_url = "http://example.com/img.png")
+        mock_prepare.assert_called_once()
         mock_resize.assert_called_once()
+        self.assertEqual(mock_resize.call_args.args[0], prepared_path)
         self.assertEqual(mock_resize.call_args.args[1], TELEGRAM_MAX_PHOTO_SIZE_BYTES)
         stored_bytes = di.chat_attachment_service.save.call_args.kwargs["content"]
         self.assertEqual(stored_bytes, b"resized")
         di.telegram_bot_sdk.send_photo.assert_called_once_with(
             di.chat_config_repo.get_by_external_identifiers.return_value.external_id,
+            di.chat_attachment_service.save.return_value,
+            None,
+        )
+        self.assertEqual(result, "sent")
+
+    def test_whatsapp_send_photo_prepares_before_resize(self):
+        di = _make_di()
+        di.require_invoker_chat_type.return_value = ChatConfigDB.ChatType.whatsapp
+        prepared_path = _make_temp_file(b"prepared")
+        sdk = PlatformBotSDK(di = di)
+        with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
+                patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
+            mock_get.return_value = _mock_response(body = b"source")
+            mock_prepare.return_value = prepared_path
+            mock_resize.return_value = prepared_path
+            result = sdk.send_photo(chat_id = 1, photo_url = "http://example.com/img.png")
+
+        mock_prepare.assert_called_once()
+        self.assertEqual(mock_resize.call_args.args[0], prepared_path)
+        di.whatsapp_bot_sdk.send_photo.assert_called_once_with(
+            di.chat_config_repo.get_by_external_identifiers.return_value,
             di.chat_attachment_service.save.return_value,
             None,
         )
@@ -149,11 +176,13 @@ class PlatformBotSDKTest(unittest.TestCase):
         di = _make_di()
         sdk = PlatformBotSDK(di = di)
         with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
                 patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
             mock_get.return_value = _mock_response(body = b"document")
             mock_resize.side_effect = lambda path, max_size_bytes: path
             result = sdk.send_document(chat_id = 1, document_url = "http://example.com/doc.pdf")
         self.assertIsNone(mock_resize.call_args.args[1])
+        mock_prepare.assert_not_called()
         stored_bytes = di.chat_attachment_service.save.call_args.kwargs["content"]
         self.assertEqual(stored_bytes, b"document")
         di.telegram_bot_sdk.send_document.assert_called_once_with(
@@ -168,6 +197,7 @@ class PlatformBotSDKTest(unittest.TestCase):
         di = _make_di()
         sdk = PlatformBotSDK(di = di)
         with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
                 patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
             mock_get.return_value = _mock_response(body = b"document")
             mock_resize.side_effect = lambda path, max_size_bytes: path
@@ -178,6 +208,7 @@ class PlatformBotSDKTest(unittest.TestCase):
                 thumbnail = "http://example.com/thumb.png",
             )
         self.assertEqual(mock_resize.call_count, 2)
+        mock_prepare.assert_not_called()
         di.chat_attachment_service.create_public_url.assert_called_once()
         di.telegram_bot_sdk.send_document.assert_called_once_with(
             chat_id = di.chat_config_repo.get_by_external_identifiers.return_value.external_id,
@@ -191,6 +222,7 @@ class PlatformBotSDKTest(unittest.TestCase):
         di = _make_di()
         sdk = PlatformBotSDK(di = di)
         with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
                 patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
             mock_get.return_value = _mock_response(body = b"document")
             mock_resize.side_effect = lambda path, max_size_bytes: path
@@ -201,14 +233,17 @@ class PlatformBotSDKTest(unittest.TestCase):
             )
         di.telegram_bot_sdk.send_photo.assert_not_called()
         di.telegram_bot_sdk.send_document.assert_called_once()
+        mock_prepare.assert_not_called()
         self.assertEqual(result, "document-sent")
 
     def test_smart_send_photo_all_mode_sends_photo_and_document(self):
         di = _make_di()
         sdk = PlatformBotSDK(di = di)
         with patch("features.integrations.platform_bot_sdk.requests.get") as mock_get, \
+                patch("features.integrations.platform_bot_sdk.add_outgoing_png_background") as mock_prepare, \
                 patch("features.integrations.platform_bot_sdk.resize_file") as mock_resize:
             mock_get.return_value = _mock_response(body = b"data")
+            mock_prepare.side_effect = lambda path: path
             mock_resize.side_effect = lambda path, max_size_bytes: path
             result = sdk.smart_send_photo(
                 media_mode = ChatConfigDB.MediaMode.all,
@@ -228,6 +263,7 @@ class PlatformBotSDKTest(unittest.TestCase):
             thumbnail = _public_attachment_url("stored-attachment"),
             caption = "caption",
         )
+        mock_prepare.assert_called_once()
         self.assertEqual(result, "document-sent")
 
     def test_smart_send_photo_photo_mode_falls_back_to_document(self):


### PR DESCRIPTION
v5.22.0 — The Background Learns the Brand 🎭

*A sharper visual update: The Agent now gives outgoing PNG images a more polished, branded look where it matters, while still preserving transparency when the original file experience is needed.*

The Agent has refined how images leave its hands.

PNG images sent **as photos** now arrive with a subtle branded background, replacing the plain forced backdrop that the chat platform used to impose. The result is cleaner, more intentional, and a little more unmistakably *The Agent*.

At the same time, The Agent knows when to stay invisible. PNG images sent **as files** still keep their transparency intact, so workflows that depend on alpha support remain untouched.

### What's new
- 🖼️ PNGs sent as **photos** now use a subtle branded background
- ✨ The Agent no longer relies on the chat platform’s default forced background for those images
- 🔍 PNGs sent **as files** still preserve their alpha transparency

A small visual shift on the surface — a more controlled signal underneath.
