### PR TITLE
Release Candidate v5.23.0

### DIFF
--- a/docs/open-api-docs.yaml
+++ b/docs/open-api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The Agent's user-facing API
   description: The user-facing parts of The Agent's API service (excluding system-level endpoints, chat completion, maintenance endpoints, etc.)
-  version: 5.22.0
+  version: 5.23.0
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/.openspec.yaml
+++ b/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-19

--- a/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/design.md
+++ b/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/design.md
@@ -1,0 +1,58 @@
+## Context
+
+Price alerts are shared per chat and use `(chat_id, base_currency, desired_currency)` as their composite identity. The chat LLM tools pass the request-scoped invoking user and chat into `CurrencyAlertService`, but the service currently checks only that a target chat exists and that the background agent is not creating an alert. Any member can therefore create or replace the shared alert for a currency pair, and any member can delete it.
+
+The project already has a platform-aware authorization boundary. `AuthorizationService.validate_chat_admin` synchronizes the invoking user's current chat membership and accepts owners or administrators. Telegram group roles are resolved through the Bot API, while the owner of a supported private chat is treated as its administrator. WhatsApp currently supports private chats only.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Restrict price-alert creation, reconfiguration, and removal to current chat administrators.
+- Keep private-chat price alerts manageable by the private-chat owner.
+- Keep active-alert listing available to chat members.
+- Enforce authorization before exchange-rate fetching or persistence mutation.
+- Reuse the existing chat-administration semantics and structured authorization error.
+
+**Non-Goals:**
+
+- Changing price-alert persistence, ownership, composite identity, triggering, delivery, or cleanup.
+- Adding WhatsApp group support or a new platform-role model.
+- Hiding price-alert tools from the LLM based on role.
+- Restricting active-alert listing to administrators.
+
+## Decisions
+
+### Enforce mutation authorization in `CurrencyAlertService`
+
+Both `create_alert` and `delete_alert` will validate the invoking user as an administrator of the target chat before performing operation-specific external calls or repository writes. Existing target-chat and background-agent guards remain intact.
+
+The service boundary protects every caller, including future callers that do not use the current LLM tool wrappers. Performing the check only in `set_up_currency_price_alert` and `remove_currency_price_alerts` was rejected because direct service calls could bypass it.
+
+### Reuse live `validate_chat_admin` authorization
+
+The service will delegate to `AuthorizationService.validate_chat_admin` with the request-scoped invoker and validated target chat. This preserves the established definitions of administrator and private-chat owner, refreshes platform membership at the protected operation, and returns the existing `NOT_CHAT_ADMIN` authorization error for ordinary members.
+
+Reading the persisted membership directly was considered, since message ingestion already synchronizes it. It was rejected for the authorization decision because it couples correctness to a particular entry path and can use stale role state. The live check adds a platform lookup for protected operations but fails closed when current administrator status cannot be established.
+
+### Treat every setup call as an administrator mutation
+
+The repository saves by composite identity and replaces an existing alert when the same chat and currency pair already exists. Authorization will therefore cover both first creation and reconfiguration through the same `create_alert` path. No separate insert-versus-update permission is introduced.
+
+### Leave read and background behavior unchanged
+
+`get_active_alerts` remains available through the current member-scoped chat flow. Scheduled alert evaluation, price refresh, notification delivery, stale cleanup, and profile ownership reassignment do not represent interactive alert management and will not receive administrator checks.
+
+## Risks / Trade-offs
+
+- [A live Telegram role lookup adds latency and may duplicate the membership sync performed during message ingestion] → Limit the additional lookup to mutating operations, where current authorization is more important than avoiding one platform request.
+- [A transient platform lookup failure can deny an administrator] → Preserve fail-closed authorization and return the existing structured authorization error without fetching a rate or mutating an alert.
+- [Non-administrators still see management tools in the LLM tool catalog] → Rely on service-side enforcement as the security boundary; tool visibility can be reconsidered separately as a prompt and UX concern.
+
+## Migration Plan
+
+No data or schema migration is required. Deploy the service authorization checks and focused tests together. Rollback consists of reverting those checks; existing price-alert data remains compatible.
+
+## Open Questions
+
+None.

--- a/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/proposal.md
+++ b/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+Price alerts are shared chat state, but any chat member can currently create, reconfigure, or remove them. Management should follow the chat's existing administration boundary so ordinary members cannot change notifications delivered to the whole chat.
+
+## What Changes
+
+- Require current chat-administrator access to create or reconfigure a price alert.
+- Require current chat-administrator access to remove a price alert.
+- Continue allowing chat members to list active price alerts.
+- Continue treating the owner of a private chat as its administrator for price-alert management.
+- Preserve scheduled alert evaluation, delivery, persistence identity, and cleanup behavior.
+
+## Capabilities
+
+### New Capabilities
+
+- `price-alert-administration`: Authorization rules for managing shared chat price alerts while retaining member visibility and private-chat ownership behavior.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Price-alert service authorization and focused service tests.
+- Existing chat-membership synchronization and `validate_chat_admin` behavior are reused.
+- No database migration, public API change, or new dependency is expected.

--- a/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/specs/price-alert-administration/spec.md
+++ b/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/specs/price-alert-administration/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Price-alert mutations require current chat-administrator access
+The system SHALL allow only a current administrator of the target chat to create, reconfigure, or remove that chat's price alerts. The system SHALL use the existing chat-administration rules, including treating the owner of a supported private chat as its administrator.
+
+#### Scenario: Administrator creates a new price alert
+- **WHEN** a current chat administrator requests a price alert for a currency pair that does not yet exist in the chat
+- **THEN** the system creates the alert for that chat
+- **THEN** the invoking administrator becomes the alert owner
+
+#### Scenario: Administrator reconfigures an existing price alert
+- **WHEN** a current chat administrator requests a price alert for a currency pair that already exists in the chat
+- **THEN** the system replaces the existing alert state using the requested threshold and current rate
+- **THEN** the invoking administrator becomes the alert owner
+
+#### Scenario: Administrator removes a price alert
+- **WHEN** a current chat administrator requests removal of a price alert in the chat
+- **THEN** the system removes the matching alert if it exists
+
+#### Scenario: Ordinary member attempts to create or reconfigure a price alert
+- **WHEN** a chat member who is not a current administrator requests creation or reconfiguration of a price alert
+- **THEN** the system rejects the request with the existing not-chat-administrator authorization error
+- **THEN** the system does not fetch the current exchange rate or persist alert state
+
+#### Scenario: Ordinary member attempts to remove a price alert
+- **WHEN** a chat member who is not a current administrator requests removal of a price alert
+- **THEN** the system rejects the request with the existing not-chat-administrator authorization error
+- **THEN** the system does not delete alert state
+
+#### Scenario: Private-chat owner manages a price alert
+- **WHEN** the owner of a supported private chat requests creation, reconfiguration, or removal of a price alert
+- **THEN** the system authorizes the operation using the existing private-chat ownership rule
+
+#### Scenario: Previously authorized user has lost administrator access
+- **WHEN** a user whose stored membership was previously administrative requests a price-alert mutation after losing platform administrator access
+- **THEN** the system refreshes the user's chat authorization
+- **THEN** the system rejects the mutation without changing alert state
+
+### Requirement: Chat members retain price-alert visibility
+The system SHALL continue allowing chat members to list the active price alerts for their current chat without requiring administrator access.
+
+#### Scenario: Ordinary member lists active price alerts
+- **WHEN** a chat member who is not an administrator requests the active price alerts for the current chat
+- **THEN** the system returns the chat's active price alerts
+
+### Requirement: Administrative controls do not alter background alert processing
+The system SHALL apply chat-administrator authorization only to interactive price-alert management and SHALL preserve existing background alert evaluation and maintenance behavior.
+
+#### Scenario: Scheduled alert evaluation processes administrator-created alerts
+- **WHEN** scheduled alert evaluation checks persisted price alerts
+- **THEN** the system evaluates, refreshes, and delivers triggered alerts without requiring an interactive administrator context
+
+#### Scenario: Stale alert cleanup runs
+- **WHEN** scheduled cleanup removes stale price alerts
+- **THEN** the system preserves the existing stale-alert deletion behavior without requiring chat-administrator authorization

--- a/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/tasks.md
+++ b/openspec/changes/archive/2026-07-19-restrict-price-alert-management-to-chat-admins/tasks.md
@@ -1,0 +1,18 @@
+## 1. Enforce Price-Alert Administration
+
+- [x] 1.1 Update `CurrencyAlertService.create_alert` to validate the current invoker as an administrator of the target chat after existing guards and before exchange-rate fetching or persistence.
+- [x] 1.2 Update `CurrencyAlertService.delete_alert` to validate the current invoker as an administrator of the target chat before repository deletion.
+- [x] 1.3 Preserve member listing and background alert evaluation paths without adding administrator checks.
+
+## 2. Verify Authorization Behavior
+
+- [x] 2.1 Extend the existing currency-alert service tests to verify administrators can create, reconfigure, and remove alerts through the shared service authorization boundary.
+- [x] 2.2 Add service tests proving non-administrators cannot create or reconfigure alerts and that denial occurs before exchange-rate fetching or persistence.
+- [x] 2.3 Add a service test proving non-administrators cannot remove alerts and that denial occurs before repository deletion.
+- [x] 2.4 Verify private-chat owner authorization delegates to the existing chat-admin validator, while listing and scheduled alert evaluation remain unaffected.
+
+## 3. Quality Checks
+
+- [x] 3.1 Run Ruff and the spacing checker on the changed Python files.
+- [x] 3.2 Run the focused currency-alert service tests offline.
+- [x] 3.3 Validate the OpenSpec change with `openspec validate restrict-price-alert-management-to-chat-admins --strict`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "the-agent"
-version = "5.22.0"
+version = "5.23.0"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/features/currencies/currency_alert_service.py
+++ b/src/features/currencies/currency_alert_service.py
@@ -59,6 +59,7 @@ class CurrencyAlertService:
         if self.__di.invoker.id == agent_user.id:
             raise AuthorizationError("Bot cannot set price alerts", BOT_CANNOT_SET_ALERTS)
 
+        self.__di.authorization_service.validate_chat_admin(self.__di.invoker, self.__target_chat_config)
         current_rate: float = self.__di.exchange_rate_fetcher.execute(base_currency, desired_currency)["rate"]
         price_alert = self.__di.price_alert_repo.save(
             PriceAlert(
@@ -86,6 +87,7 @@ class CurrencyAlertService:
         if not self.__target_chat_config:
             raise AuthorizationError("Target chat is not set", NO_PRIVATE_CHAT)
 
+        self.__di.authorization_service.validate_chat_admin(self.__di.invoker, self.__target_chat_config)
         deleted_alert = self.__di.price_alert_repo.delete(
             self.__target_chat_config.chat_id, base_currency, desired_currency,
         )

--- a/test/features/currencies/test_currency_alert_service.py
+++ b/test/features/currencies/test_currency_alert_service.py
@@ -3,19 +3,26 @@ from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import UUID
 
+from db.sql_util import SQLUtil
 from pydantic import SecretStr
 
+from api.authorization_service import AuthorizationService
 from db.model.chat_config import ChatConfigDB
 from db.model.user import UserDB
 from di.di import DI
 from features.chat.config.chat_config import ChatConfig
+from features.chat.membership.chat_membership import ChatMembership
+from features.chat.membership.chat_membership_service import ChatMembershipService
 from features.chat.telegram.sdk.telegram_bot_sdk import TelegramBotSDK
 from features.currencies.currency_alert_service import DATETIME_PRINT_FORMAT, CurrencyAlertService
 from features.currencies.exchange_rate_fetcher import ExchangeRateFetcher
 from features.currencies.price_alert import PriceAlert
 from features.currencies.price_alert_repo import PriceAlertRepository
+from features.integrations.platform_bot_sdk import ChatAccess
 from features.sponsorships.sponsorship_repo import SponsorshipRepository
 from features.users.user import User
+from util.error_codes import NOT_CHAT_ADMIN
+from util.errors import AuthorizationError
 
 
 class CurrencyAlertServiceTest(unittest.TestCase):
@@ -58,6 +65,56 @@ class CurrencyAlertServiceTest(unittest.TestCase):
         )
         self.mock_di.authorization_service.validate_chat.return_value = self.chat_config
 
+    def _role_checked_service(
+        self,
+        access: ChatAccess,
+        is_private: bool = False,
+        existing_is_admin: bool | None = None,
+    ) -> tuple[CurrencyAlertService, DI, SQLUtil, User, ChatConfig]:
+        sql = SQLUtil()
+        self.addCleanup(sql.end_session)
+        user = sql.user_repo().save(
+            User(
+                full_name = "Role User",
+                telegram_username = "role_user",
+                telegram_chat_id = "private_chat",
+                telegram_user_id = 123,
+                open_ai_key = SecretStr("test_api_key"),
+                group = UserDB.Group.standard,
+                created_at = datetime.now().date(),
+            ),
+        )
+        chat = sql.chat_config_repo().save(
+            ChatConfig(
+                external_id = "private_chat" if is_private else "group_chat",
+                title = "Role Chat",
+                is_private = is_private,
+                chat_type = ChatConfigDB.ChatType.telegram,
+            ),
+        )
+        if existing_is_admin is not None:
+            sql.chat_membership_repo().save(
+                ChatMembership(
+                    user_id = user.id,
+                    chat_id = chat.chat_id,
+                    is_admin = existing_is_admin,
+                ),
+            )
+
+        di = MagicMock(spec = DI)
+        di.user_repo = sql.user_repo()
+        di.chat_config_repo = sql.chat_config_repo()
+        di.chat_membership_repo = sql.chat_membership_repo()
+        di.price_alert_repo = sql.price_alert_repo()
+        di.exchange_rate_fetcher = MagicMock(spec = ExchangeRateFetcher)
+        di.invoker = user
+        platform_sdk = MagicMock()
+        platform_sdk.resolve_chat_access.return_value = access
+        di.platform_bot_sdk.return_value = platform_sdk
+        di.chat_membership_service = ChatMembershipService(di)
+        di.authorization_service = AuthorizationService(di)
+        return CurrencyAlertService(chat.chat_id.hex, di), di, sql, user, chat
+
     def test_create_alert(self):
         service = CurrencyAlertService(self.chat_id, self.mock_di)
         self.mock_price_alert_repo.save.return_value = PriceAlert(
@@ -83,6 +140,54 @@ class CurrencyAlertServiceTest(unittest.TestCase):
         self.assertEqual(saved.desired_currency, "USD")
         self.assertEqual(saved.threshold_percent, 5)
         self.assertEqual(saved.last_price, 1.5)
+
+    def test_admin_can_create_alert(self):
+        service, di, sql, user, chat = self._role_checked_service(ChatAccess.admin)
+        di.exchange_rate_fetcher.execute.return_value = {"rate": 1.5}
+
+        alert = service.create_alert("BTC", "USD", 5)
+
+        stored = sql.price_alert_repo().get(chat.chat_id, "BTC", "USD")
+        self.assertIsNotNone(stored)
+        self.assertEqual(alert.owner_id, user.id)
+        self.assertEqual(stored.owner_id, user.id)
+        self.assertEqual(stored.threshold_percent, 5)
+        self.assertEqual(stored.last_price, 1.5)
+
+    def test_admin_can_reconfigure_alert(self):
+        service, di, sql, user, chat = self._role_checked_service(ChatAccess.admin)
+        sql.price_alert_repo().save(
+            PriceAlert(
+                chat_id = chat.chat_id,
+                owner_id = user.id,
+                base_currency = "BTC",
+                desired_currency = "USD",
+                threshold_percent = 5,
+                last_price = 1.5,
+                last_price_time = datetime(2023, 1, 1, 12, 0, 0),
+            ),
+        )
+        di.exchange_rate_fetcher.execute.return_value = {"rate": 2.5}
+
+        alert = service.create_alert("BTC", "USD", 8)
+
+        stored = sql.price_alert_repo().get(chat.chat_id, "BTC", "USD")
+        self.assertIsNotNone(stored)
+        self.assertEqual(alert.threshold_percent, 8)
+        self.assertEqual(stored.owner_id, user.id)
+        self.assertEqual(stored.threshold_percent, 8)
+        self.assertEqual(stored.last_price, 2.5)
+
+    def test_private_chat_owner_can_create_alert(self):
+        service, di, sql, user, chat = self._role_checked_service(ChatAccess.owner, is_private = True)
+        di.exchange_rate_fetcher.execute.return_value = {"rate": 1.5}
+
+        service.create_alert("BTC", "USD", 5)
+
+        stored = sql.price_alert_repo().get(chat.chat_id, "BTC", "USD")
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.owner_id, user.id)
+        self.assertEqual(stored.threshold_percent, 5)
 
     def test_get_all_alerts(self):
         service = CurrencyAlertService(self.chat_id, self.mock_di)
@@ -140,6 +245,119 @@ class CurrencyAlertServiceTest(unittest.TestCase):
         self.assertEqual(deleted_alert.desired_currency, "USD")
         self.mock_price_alert_repo.delete.assert_called_once_with(UUID(hex = self.chat_id), "BTC", "USD")
 
+    def test_admin_can_delete_alert(self):
+        service, _, sql, user, chat = self._role_checked_service(ChatAccess.admin)
+        sql.price_alert_repo().save(
+            PriceAlert(
+                chat_id = chat.chat_id,
+                owner_id = user.id,
+                base_currency = "BTC",
+                desired_currency = "USD",
+                threshold_percent = 5,
+                last_price = 1.5,
+            ),
+        )
+
+        deleted_alert = service.delete_alert("BTC", "USD")
+
+        self.assertIsNotNone(deleted_alert)
+        self.assertIsNone(sql.price_alert_repo().get(chat.chat_id, "BTC", "USD"))
+
+    def test_member_cannot_create_alert(self):
+        service, di, sql, _, chat = self._role_checked_service(ChatAccess.member)
+
+        with self.assertRaises(AuthorizationError) as context:
+            service.create_alert("BTC", "USD", 5)
+
+        self.assertEqual(context.exception.error_code, NOT_CHAT_ADMIN)
+        di.exchange_rate_fetcher.execute.assert_not_called()
+        self.assertIsNone(sql.price_alert_repo().get(chat.chat_id, "BTC", "USD"))
+
+    def test_member_cannot_reconfigure_alert(self):
+        service, di, sql, user, chat = self._role_checked_service(ChatAccess.member)
+        original_time = datetime(2023, 1, 1, 12, 0, 0)
+        sql.price_alert_repo().save(
+            PriceAlert(
+                chat_id = chat.chat_id,
+                owner_id = user.id,
+                base_currency = "BTC",
+                desired_currency = "USD",
+                threshold_percent = 5,
+                last_price = 1.5,
+                last_price_time = original_time,
+            ),
+        )
+
+        with self.assertRaises(AuthorizationError) as context:
+            service.create_alert("BTC", "USD", 8)
+
+        self.assertEqual(context.exception.error_code, NOT_CHAT_ADMIN)
+        di.exchange_rate_fetcher.execute.assert_not_called()
+        stored = sql.price_alert_repo().get(chat.chat_id, "BTC", "USD")
+        self.assertIsNotNone(stored)
+        self.assertEqual(stored.threshold_percent, 5)
+        self.assertEqual(stored.last_price, 1.5)
+        self.assertEqual(stored.last_price_time, original_time)
+
+    def test_member_cannot_delete_alert(self):
+        service, _, sql, user, chat = self._role_checked_service(ChatAccess.member)
+        sql.price_alert_repo().save(
+            PriceAlert(
+                chat_id = chat.chat_id,
+                owner_id = user.id,
+                base_currency = "BTC",
+                desired_currency = "USD",
+                threshold_percent = 5,
+                last_price = 1.5,
+            ),
+        )
+
+        with self.assertRaises(AuthorizationError) as context:
+            service.delete_alert("BTC", "USD")
+
+        self.assertEqual(context.exception.error_code, NOT_CHAT_ADMIN)
+        self.assertIsNotNone(sql.price_alert_repo().get(chat.chat_id, "BTC", "USD"))
+
+    def test_lost_admin_role_cannot_create_alert(self):
+        service, di, sql, user, chat = self._role_checked_service(ChatAccess.member, existing_is_admin = True)
+
+        with self.assertRaises(AuthorizationError) as context:
+            service.create_alert("BTC", "USD", 5)
+
+        self.assertEqual(context.exception.error_code, NOT_CHAT_ADMIN)
+        di.exchange_rate_fetcher.execute.assert_not_called()
+        self.assertIsNone(sql.price_alert_repo().get(chat.chat_id, "BTC", "USD"))
+        membership = sql.chat_membership_repo().get(user.id, chat.chat_id)
+        self.assertIsNotNone(membership)
+        self.assertFalse(membership.is_admin)
+
+    def test_non_participant_cannot_create_alert(self):
+        service, di, sql, _, chat = self._role_checked_service(None)
+
+        with self.assertRaises(AuthorizationError):
+            service.create_alert("BTC", "USD", 5)
+
+        di.exchange_rate_fetcher.execute.assert_not_called()
+        self.assertIsNone(sql.price_alert_repo().get(chat.chat_id, "BTC", "USD"))
+
+    def test_listing_does_not_require_admin_role(self):
+        service, _, sql, user, chat = self._role_checked_service(ChatAccess.member)
+        sql.price_alert_repo().save(
+            PriceAlert(
+                chat_id = chat.chat_id,
+                owner_id = user.id,
+                base_currency = "BTC",
+                desired_currency = "USD",
+                threshold_percent = 5,
+                last_price = 1.5,
+            ),
+        )
+
+        alerts = service.get_active_alerts()
+
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0].base_currency, "BTC")
+
     def test_triggered_alert_refreshes_only_price_state(self):
         service = CurrencyAlertService(self.chat_id, self.mock_di)
         last_price_time = datetime(2023, 1, 1, 12, 0, 0)
@@ -172,6 +390,7 @@ class CurrencyAlertServiceTest(unittest.TestCase):
         self.assertEqual(refreshed.threshold_percent, existing.threshold_percent)
         self.assertEqual(refreshed.last_price, 1100)
         self.assertGreater(refreshed.last_price_time, existing.last_price_time)
+        self.mock_di.authorization_service.validate_chat_admin.assert_not_called()
 
     def test_triggered_alert_with_zero_last_price(self):
         service = CurrencyAlertService(self.chat_id, self.mock_di)


### PR DESCRIPTION
v5.23.0 — The Watchers Learned New Rules 👁️⚙️

**A sharper release with stronger guardrails and updated internal standards to help The Agent stay more controlled, aware, and reliable.**

The Agent has stepped into **v5.23.0** with a quieter kind of power.

This release tightens how sensitive alert actions are handled. The Agent now applies **admin checks when creating and deleting alerts**, adding an extra layer of control around who can trigger those changes. Fewer loose ends. Fewer surprises in the dark.

It also refreshes **internal specifications**, helping keep The Agent’s foundations aligned and up to date beneath the surface. Not every improvement announces itself loudly—some simply make the machine more certain of its next move.

### What changed
- 🔐 The Agent now requires proper admin permissions for **creating alerts**
- 🗑️ The Agent now requires proper admin permissions for **deleting alerts**
- 📘 The Agent’s internal specs were **updated and refreshed**

A small release on the surface. A stricter mind underneath.
