### PR TITLE
Release Candidate v5.23.2

### DIFF
--- a/docs/open-api-docs.yaml
+++ b/docs/open-api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The Agent's user-facing API
   description: The user-facing parts of The Agent's API service (excluding system-level endpoints, chat completion, maintenance endpoints, etc.)
-  version: 5.23.0
+  version: 5.23.1
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/docs/open-api-docs.yaml
+++ b/docs/open-api-docs.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: The Agent's user-facing API
   description: The user-facing parts of The Agent's API service (excluding system-level endpoints, chat completion, maintenance endpoints, etc.)
-  version: 5.23.1
+  version: 5.23.2
   license:
     name: MIT
     url: https://opensource.org/licenses/MIT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "the-agent"
-version = "5.23.1"
+version = "5.23.2"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "the-agent"
-version = "5.23.0"
+version = "5.23.1"
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/src/features/chat/chat_agent.py
+++ b/src/features/chat/chat_agent.py
@@ -1,8 +1,6 @@
 import random
-import re
 import time
 from dataclasses import dataclass
-from itertools import chain
 from typing import Any, TypeVar
 
 from langchain_core.language_models import LanguageModelInput
@@ -13,11 +11,11 @@ from db.model.chat_config import ChatConfigDB
 from di.di import DI
 from features.chat.command_processor import is_known_command
 from features.chat.message.chat_message import ChatMessage
+from features.chat.message.formatted_chat_message import ATTACHMENT_PLACEHOLDER_REGEX
 from features.external_tools.configured_tool import ConfiguredTool
 from features.external_tools.external_tool import ToolType
 from features.integrations import prompt_resolvers
 from features.integrations.integrations import resolve_agent_user, resolve_external_handle
-from features.prompting import prompt_library
 from util import log
 from util.config import config
 from util.error_codes import (
@@ -44,7 +42,6 @@ class ChatAgent:
     __messages: list[BaseMessage]
     __raw_last_message: str  # excludes the resolver formatting
     __last_message_id: str
-    __attachment_ids: list[str]
     __configured_tool: ConfiguredTool | None
     __max_iterations: int
     __di: DI
@@ -75,13 +72,6 @@ class ChatAgent:
             limit = invoker_membership.max_chat_history_depth,
         )
         langchain_messages = [self.__map_to_langchain(di, message, chat_type) for message in past_messages][::-1]
-        self.__attachment_ids = [
-            attachment.id
-            for attachment in chain.from_iterable(
-                di.chat_attachment_repo.get_all_by_message(message.chat_id, message.message_id)
-                for message in past_messages
-            )
-        ]
         system_prompt = prompt_resolvers.chat(
             invoker = di.invoker,
             target_chat = target_chat,
@@ -186,23 +176,7 @@ class ChatAgent:
                     log.d(f"Iteration #{iteration} has no tool calls.")
                     if not isinstance(answer, AIMessage):
                         raise ExternalServiceError(f"Received a non-AI message from LLM: {answer}", LLM_UNEXPECTED_RESPONSE)
-                    system_correction_added = False
-                    for attachment_id in self.__attachment_ids:
-                        clean_attachment_id = re.sub(r"[ _-]", "", attachment_id)
-                        truncated_attachment_id = attachment_id[-10:]
-                        if (
-                            attachment_id in str(answer.content)
-                            or clean_attachment_id in str(answer.content)
-                            or truncated_attachment_id in str(answer.content)
-                        ):
-                            log.w("Found approximate attachment ID in the answer, adding system correction")
-                            system_correction = AIMessage(prompt_library.metas.attachment_id_correction.content)
-                            self.__add_message(system_correction)
-                            system_correction_added = True
-                            break
-                    if system_correction_added:
-                        iteration += 1
-                        continue
+                    self.__remove_attachment_placeholder_content(answer)
                     log.i(f"Finishing chat response with {len(answer.content)} characters")
                     return answer
 
@@ -256,6 +230,44 @@ class ChatAgent:
             return ChatAgent.CommandHandlingResult(is_handled = False, reply = None)
         message = prompt_resolvers.simple_chat_error("Confused with processing command.")
         return ChatAgent.CommandHandlingResult(is_handled = True, reply = AIMessage(message))
+
+    @classmethod
+    def __remove_attachment_placeholder_content(cls, message: AIMessage) -> None:
+        content = message.content
+        if isinstance(content, str):
+            message.content = cls.__remove_attachment_placeholder_lines(content)
+            return
+        if isinstance(content, list):
+            cleaned_content = []
+            for block in content:
+                if isinstance(block, str):
+                    cleaned_block = cls.__remove_attachment_placeholder_lines(block)
+                    if cleaned_block:
+                        cleaned_content.append(cleaned_block)
+                elif isinstance(block, dict) and block.get("type") == "text" and isinstance(block.get("text"), str):
+                    cleaned_block = {
+                        **block,
+                        "text": cls.__remove_attachment_placeholder_lines(block["text"]),
+                    }
+                    if cleaned_block["text"]:
+                        cleaned_content.append(cleaned_block)
+                else:
+                    cleaned_content.append(block)
+            message.content = cleaned_content
+
+    @staticmethod
+    def __remove_attachment_placeholder_lines(text: str) -> str:
+        paragraphs = []
+        for paragraph in text.split("\n\n"):
+            lines = [
+                line
+                for line in paragraph.split("\n")
+                if not ATTACHMENT_PLACEHOLDER_REGEX.search(line)
+            ]
+            cleaned_paragraph = "\n".join(lines).strip()
+            if cleaned_paragraph:
+                paragraphs.append(cleaned_paragraph)
+        return "\n\n".join(paragraphs)
 
     def __is_dispatchable(self) -> bool:
         has_content = bool(self.__raw_last_message.strip())

--- a/src/features/chat/message/formatted_chat_message.py
+++ b/src/features/chat/message/formatted_chat_message.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+
+from features.chat.attachment.chat_attachment import ChatAttachment
+from features.chat.attachment.chat_attachment_remote_data import ChatAttachmentRemoteData
+from util.functions import generate_deterministic_short_uuid as uuid_of
+
+ATTACHMENT_PLACEHOLDER_TEXT = "📎 [ {attachments} ]"
+ATTACHMENT_PLACEHOLDER_REGEX = re.compile(r"📎 \[ [^\]\r\n]+ \]")
+
+
+@dataclass(kw_only = True)
+class FormattedAttachmentReference:
+    """A reference to one attachment in a formatted message.
+
+    Example::
+
+        a1 (image/png)
+    """
+
+    id: str
+    mime_type: str | None = None
+
+    @classmethod
+    def from_attachment(cls, attachment: ChatAttachment) -> FormattedAttachmentReference:
+        return cls(id = attachment.id, mime_type = attachment.mime_type)
+
+    @classmethod
+    def from_remote_data(cls, attachment: ChatAttachmentRemoteData) -> FormattedAttachmentReference:
+        return cls(id = uuid_of(attachment.external_id), mime_type = attachment.mime_type)
+
+    def to_text(self) -> str:
+        return f"{self.id} ({self.mime_type})" if self.mime_type else self.id
+
+
+@dataclass(kw_only = True)
+class FormattedTextPart:
+    """A plain-text part of a formatted message.
+
+    Example::
+
+        Hello
+    """
+
+    text: str | None
+
+    def to_text(self) -> str:
+        return self.text or ""
+
+
+@dataclass(kw_only = True)
+class FormattedAttachmentPart:
+    """The attachment placeholder part of a formatted message.
+
+    Example::
+
+        📎 [ a1 (image/png) ]
+    """
+
+    attachments: list[FormattedAttachmentReference]
+
+    @classmethod
+    def from_attachments(cls, attachments: list[ChatAttachment]) -> FormattedAttachmentPart:
+        return cls(
+            attachments = [
+                FormattedAttachmentReference.from_attachment(attachment)
+                for attachment in attachments
+            ],
+        )
+
+    @classmethod
+    def from_remote_data(cls, attachments: list[ChatAttachmentRemoteData]) -> FormattedAttachmentPart:
+        return cls(
+            attachments = [
+                FormattedAttachmentReference.from_remote_data(attachment)
+                for attachment in attachments
+            ],
+        )
+
+    def to_text(self) -> str:
+        if not self.attachments:
+            return ""
+        attachments = ", ".join(attachment.to_text() for attachment in self.attachments)
+        return ATTACHMENT_PLACEHOLDER_TEXT.format(attachments = attachments)
+
+
+@dataclass(kw_only = True)
+class FormattedQuotePart:
+    """A quoted message part, with its nesting depth reflected in the prefix.
+
+    Example::
+
+        >> Earlier message
+    """
+
+    message: FormattedChatMessage
+    depth: int = 1
+
+    def to_text(self) -> str:
+        text = self.message.to_text()
+        if not text:
+            return ""
+        prefix = ">>" * self.depth
+        paragraphs = [
+            "\n".join(f"{prefix} {line}" for line in paragraph.split("\n"))
+            for paragraph in text.split("\n\n")
+        ]
+        return "\n\n".join(paragraphs)
+
+
+type FormattedChatMessagePart = FormattedTextPart | FormattedAttachmentPart | FormattedQuotePart
+
+
+@dataclass(kw_only = True)
+class FormattedChatMessage:
+    """A message assembled from structured text, attachment, and quote parts.
+
+    Example::
+
+        Photo caption
+
+        📎 [ a1 (image/png) ]
+    """
+
+    parts: list[FormattedChatMessagePart] = field(default_factory = list)
+
+    @classmethod
+    def from_text(
+        cls,
+        text: str,
+        attachments: list[ChatAttachment] | None = None,
+    ) -> FormattedChatMessage:
+        text_parts = [
+            part
+            for part in text.split("\n\n")
+            if not ATTACHMENT_PLACEHOLDER_REGEX.fullmatch(part)
+        ]
+        parts: list[FormattedChatMessagePart] = [
+            FormattedTextPart(text = "\n\n".join(text_parts)),
+        ] if text_parts else []
+        if attachments:
+            parts.append(FormattedAttachmentPart.from_attachments(attachments))
+        return cls(parts = parts)
+
+    def with_attachments(self, attachments: list[ChatAttachment]) -> FormattedChatMessage:
+        parts = [
+            part
+            for part in self.parts
+            if not isinstance(part, FormattedAttachmentPart)
+        ]
+        if attachments:
+            parts.append(FormattedAttachmentPart.from_attachments(attachments))
+        return FormattedChatMessage(parts = parts)
+
+    def prepend_quote(self, message: FormattedChatMessage) -> FormattedChatMessage:
+        return FormattedChatMessage(parts = [FormattedQuotePart(message = message, depth = 2), *self.parts])
+
+    def to_text(self) -> str:
+        return "\n\n".join(
+            text
+            for part in self.parts
+            if (text := part.to_text())
+        )

--- a/src/features/chat/telegram/sdk/telegram_bot_sdk.py
+++ b/src/features/chat/telegram/sdk/telegram_bot_sdk.py
@@ -5,6 +5,7 @@ from typing import Literal
 from di.di import DI
 from features.chat.attachment.chat_attachment import ChatAttachment
 from features.chat.message.chat_message import ChatMessage
+from features.chat.message.formatted_chat_message import FormattedChatMessage
 from features.chat.telegram.model.chat_member import ChatMember
 from features.chat.telegram.model.message import Message
 from features.chat.telegram.model.update import Update
@@ -57,7 +58,7 @@ class TelegramBotSDK:
             parse_mode = parse_mode,
             disable_notification = disable_notification,
         )
-        message = self.__store_api_response_as_message(sent_message)
+        message = self.__store_api_response_as_message(sent_message, local_attachments = [attachment])
         # we should now quickly update the attachment record with the new ID
         self.__di.chat_attachment_service.save(replace(attachment, message_id = message.message_id))
         return message
@@ -82,7 +83,7 @@ class TelegramBotSDK:
             thumbnail = thumbnail,
             disable_notification = disable_notification,
         )
-        message = self.__store_api_response_as_message(sent_message)
+        message = self.__store_api_response_as_message(sent_message, local_attachments = [attachment])
         # we should now quickly update the attachment record with the new ID
         self.__di.chat_attachment_service.save(replace(attachment, message_id = message.message_id))
         return message
@@ -122,13 +123,25 @@ class TelegramBotSDK:
 
     # === Data utilities ===
 
-    def __store_api_response_as_message(self, raw_api_response: dict) -> ChatMessage:
+    def __store_api_response_as_message(
+        self,
+        raw_api_response: dict,
+        local_attachments: list[ChatAttachment] | None = None,
+    ) -> ChatMessage:
         log.t("Storing API message data...")
         message = Message(**raw_api_response["result"])
         update = Update(update_id = time.time_ns(), message = message)
         mapping_result = self.__di.telegram_domain_mapper.map_update(update)
         if not mapping_result:
             raise InternalError(f"Telegram API domain mapping failed for local update '{update.update_id}'", PLATFORM_MAPPING_FAILED)  # noqa: E501
+        if local_attachments:
+            formatted_message = mapping_result.formatted_message or FormattedChatMessage.from_text(mapping_result.message.text)
+            formatted_message = formatted_message.with_attachments(local_attachments)
+            mapping_result = replace(
+                mapping_result,
+                message = replace(mapping_result.message, text = formatted_message.to_text()),
+                formatted_message = formatted_message,
+            )
         resolution_result = self.__di.telegram_data_resolver.resolve(mapping_result)
         if not resolution_result.message:
             raise InternalError(f"Telegram data resolution failed for local update '{update.update_id}'", PLATFORM_MAPPING_FAILED)

--- a/src/features/chat/telegram/telegram_data_resolver.py
+++ b/src/features/chat/telegram/telegram_data_resolver.py
@@ -1,7 +1,5 @@
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from uuid import UUID
-
-from pydantic import BaseModel
 
 from db.model.chat_config import ChatConfigDB
 from di.di import DI
@@ -13,6 +11,7 @@ from features.chat.message.chat_message import ChatMessage
 from features.chat.message.chat_message_mapper import apply_remote_data as apply_remote_data_message
 from features.chat.message.chat_message_mapper import from_remote_data as from_remote_data_message
 from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
+from features.chat.message.formatted_chat_message import FormattedChatMessage
 from features.chat.telegram.telegram_domain_mapper import TelegramDomainMapper
 from features.integrations.integrations import is_the_agent
 from features.users.user import User
@@ -31,7 +30,8 @@ class TelegramDataResolver:
     If needed, this resolver will fetch more data from the API or the database.
     """
 
-    class Result(BaseModel):
+    @dataclass(kw_only = True)
+    class Result:
         chat: ChatConfig
         author: User | None
         message: ChatMessage
@@ -57,25 +57,44 @@ class TelegramDataResolver:
         # ensure a membership row exists for real users (skip the agent itself)
         if resolved_author and not is_author_the_agent:
             self.__di.chat_membership_service.sync(resolved_author, resolved_chat_config)
-        # we need to set the resolved chat's UUID to the message
-        resolved_chat_message = self.resolve_chat_message(
-            mapped_data = mapping_result.message,
-            chat_id = resolved_chat_config.chat_id,
-            author_id = resolved_author.id if resolved_author else None,
-        )
+        should_resolve_attachments = bool(mapping_result.attachments and not is_author_the_agent)
+        if should_resolve_attachments:
+            initial_message = self.__resolve_message_content(
+                mapping_result = mapping_result,
+                chat_id = resolved_chat_config.chat_id,
+                attachments = [],
+                should_replace_attachments = True,
+            )
+            self.resolve_chat_message(
+                mapped_data = initial_message,
+                chat_id = resolved_chat_config.chat_id,
+                author_id = resolved_author.id if resolved_author else None,
+            )
         resolved_attachments: list[ChatAttachment] = []
         # skip attachment resolution for the agent's own messages — the SDK already archives outbound media
-        if mapping_result.attachments and not is_author_the_agent:
+        if should_resolve_attachments:
             if not resolved_author or not resolved_author.id:
                 raise InternalError("Telegram attachment cannot be resolved without a message author", PLATFORM_MAPPING_FAILED)
             resolved_attachments = [
                 self.resolve_chat_attachment(
                     attachment,
-                    resolved_chat_message.chat_id,
+                    resolved_chat_config.chat_id,
                     resolved_author.id,
                 )
                 for attachment in mapping_result.attachments
             ]
+        remote_message = self.__resolve_message_content(
+            mapping_result = mapping_result,
+            chat_id = resolved_chat_config.chat_id,
+            attachments = resolved_attachments,
+            should_replace_attachments = should_resolve_attachments,
+        )
+        # we need to set the resolved chat's UUID to the message
+        resolved_chat_message = self.resolve_chat_message(
+            mapped_data = remote_message,
+            chat_id = resolved_chat_config.chat_id,
+            author_id = resolved_author.id if resolved_author else None,
+        )
         return TelegramDataResolver.Result(
             chat = resolved_chat_config,
             author = resolved_author,
@@ -125,3 +144,31 @@ class TelegramDataResolver:
                 f"Could not download Telegram file '{draft_attachment.external_id}'", MEDIA_DOWNLOAD_FAILED,
             )
         return self.__di.chat_attachment_service.save(draft_attachment, content)
+
+    def __resolve_message_content(
+        self,
+        mapping_result: TelegramDomainMapper.Result,
+        chat_id: UUID,
+        attachments: list[ChatAttachment],
+        should_replace_attachments: bool,
+    ) -> ChatMessageRemoteData:
+        formatted_message = mapping_result.formatted_message or FormattedChatMessage.from_text(mapping_result.message.text)
+        if should_replace_attachments:
+            formatted_message = formatted_message.with_attachments(attachments)
+        if mapping_result.replied_to_message_id:
+            replied_message = self.__di.chat_message_repo.get(chat_id, mapping_result.replied_to_message_id)
+            if replied_message:
+                replied_attachments = self.__di.chat_attachment_repo.get_all_by_message(
+                    replied_message.chat_id,
+                    replied_message.message_id,
+                )
+                formatted_message = formatted_message.prepend_quote(
+                    FormattedChatMessage.from_text(replied_message.text, replied_attachments),
+                )
+            else:
+                log.w(f"  Replied-to message '{mapping_result.replied_to_message_id}' not found in DB")
+        return ChatMessageRemoteData(
+            message_id = mapping_result.message.message_id,
+            sent_at = mapping_result.message.sent_at,
+            text = formatted_message.to_text(),
+        )

--- a/src/features/chat/telegram/telegram_domain_mapper.py
+++ b/src/features/chat/telegram/telegram_domain_mapper.py
@@ -1,27 +1,35 @@
+from dataclasses import dataclass
 from datetime import datetime
-
-from pydantic import BaseModel
 
 from db.model.chat_config import ChatConfigDB
 from features.chat.attachment.chat_attachment_remote_data import ChatAttachmentRemoteData
 from features.chat.config.chat_config_remote_data import ChatConfigRemoteData
 from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
+from features.chat.message.formatted_chat_message import (
+    FormattedAttachmentPart,
+    FormattedChatMessage,
+    FormattedQuotePart,
+    FormattedTextPart,
+)
 from features.chat.telegram.model.attachment.file import File
-from features.chat.telegram.model.message import Message
+from features.chat.telegram.model.message import Message as TelegramMessage
 from features.chat.telegram.model.update import Update
 from features.users.user_remote_data import UserRemoteData
 from util import log
 from util.config import config
-from util.functions import generate_deterministic_short_uuid
 
 
 class TelegramDomainMapper:
 
-    class Result(BaseModel):
+    @dataclass(kw_only = True)
+    class Result:
+
         chat: ChatConfigRemoteData
         author: UserRemoteData | None
         message: ChatMessageRemoteData
+        formatted_message: FormattedChatMessage | None = None
         attachments: list[ChatAttachmentRemoteData]
+        replied_to_message_id: str | None = None
 
     def map_update(self, update: Update) -> Result | None:
         log.t(f"Mapping Telegram update: {update}")
@@ -31,25 +39,33 @@ class TelegramDomainMapper:
             return None
         result_chat = self.map_chat(message)
         result_author = self.map_author(message)
-        result_message = self.map_message(message)
         result_attachments = self.map_attachments(message)
+        result_formatted_message = self.map_content(message, result_attachments)
+        result_message = self.map_message(message, result_formatted_message)
+        replied_to_message_id = str(message.reply_to_message.message_id) if message.reply_to_message else None
         return TelegramDomainMapper.Result(
             chat = result_chat,
             author = result_author,
             message = result_message,
+            formatted_message = result_formatted_message,
             attachments = result_attachments,
+            replied_to_message_id = replied_to_message_id,
         )
 
-    def map_message(self, message: Message) -> ChatMessageRemoteData:
+    def map_message(self,
+        message: TelegramMessage,
+        formatted_message: FormattedChatMessage | None = None,
+    ) -> ChatMessageRemoteData:
         log.t(f"  Mapping message: {message}")
+        formatted_message = formatted_message or self.map_content(message)
         return ChatMessageRemoteData(
             message_id = str(message.message_id),
             sent_at = datetime.fromtimestamp(message.edit_date or message.date),
-            text = self.map_text(message),
+            text = formatted_message.to_text(),
         )
 
     # noinspection PyMethodMayBeStatic
-    def map_author(self, message: Message) -> UserRemoteData | None:
+    def map_author(self, message: TelegramMessage) -> UserRemoteData | None:
         if not message.from_user:
             return None
         log.t(f"  Mapping author {message.from_user}")
@@ -62,37 +78,30 @@ class TelegramDomainMapper:
             telegram_user_id = author.id,
         )
 
-    def map_text_as_reply(self, message: Message) -> str:
+    def map_content(
+        self,
+        message: TelegramMessage,
+        attachments: list[ChatAttachmentRemoteData] | None = None,
+    ) -> FormattedChatMessage:
         parts = []
-        if message.caption:
-            parts.append(f">>>> {message.caption}")
-        if message.text:
-            parts.append(f">>>> {message.text}")
-        attachments_as_text = self.map_attachments_as_text(message)
-        if attachments_as_text:
-            parts.append(f">>>> 📎 {attachments_as_text}")
-        log.t(f"  Mapping reply message text: {parts}")
-        return "\n\n".join(parts)
-
-    def map_text(self, message: Message) -> str:
-        parts = []
-        reply_text = self.map_text_as_reply(message.reply_to_message) if message.reply_to_message else None
-        if reply_text:
-            parts.append(f"{reply_text}")
         quote = message.quote.text if message.quote else None
         if quote:
-            parts.append(f">> {quote}")
+            parts.append(
+                FormattedQuotePart(message = FormattedChatMessage(parts = [
+                    FormattedTextPart(text = quote),
+                ])),
+            )
         if message.caption:
-            parts.append(f"{message.caption}")
+            parts.append(FormattedTextPart(text = message.caption))
         if message.text:
-            parts.append(message.text)
-        attachments_as_text = self.map_attachments_as_text(message)
-        if attachments_as_text:
-            parts.append(f"📎 {attachments_as_text}")
+            parts.append(FormattedTextPart(text = message.text))
+        attachments = attachments if attachments is not None else self.map_attachments(message)
+        if attachments:
+            parts.append(FormattedAttachmentPart.from_remote_data(attachments))
         log.t(f"  Mapping message text: {parts}")
-        return "\n\n".join(parts)
+        return FormattedChatMessage(parts = parts)
 
-    def map_chat(self, message: Message) -> ChatConfigRemoteData:
+    def map_chat(self, message: TelegramMessage) -> ChatConfigRemoteData:
         chat = message.chat
         log.t(f"  Mapping chat: {chat}")
         title = self.resolve_chat_name(str(chat.id), chat.title, chat.username, chat.first_name, chat.last_name)
@@ -130,20 +139,7 @@ class TelegramDomainMapper:
         log.t(f"  Resolved chat name {result}")
         return result
 
-    def map_attachments_as_text(self, message: Message) -> str | None:
-        attachments = self.map_attachments(message)
-        if not attachments:
-            return None
-        formatted_attachments = [
-            f"{generate_deterministic_short_uuid(attachment.external_id)} ({attachment.mime_type})"
-            if attachment.mime_type
-            else generate_deterministic_short_uuid(attachment.external_id)
-            for attachment in attachments
-        ]
-        log.t(f"  Mapping attachments: {formatted_attachments}")
-        return f"[ {', '.join(formatted_attachments)} ]"
-
-    def map_attachments(self, message: Message) -> list[ChatAttachmentRemoteData]:
+    def map_attachments(self, message: TelegramMessage) -> list[ChatAttachmentRemoteData]:
         attachments: list[ChatAttachmentRemoteData] = []
         if message.audio:
             log.t(f"  Mapping audio: {message.audio}")

--- a/src/features/chat/whatsapp/sdk/whatsapp_bot_sdk.py
+++ b/src/features/chat/whatsapp/sdk/whatsapp_bot_sdk.py
@@ -6,6 +6,7 @@ from di.di import DI
 from features.chat.attachment.chat_attachment import ChatAttachment
 from features.chat.config.chat_config import ChatConfig
 from features.chat.message.chat_message import ChatMessage
+from features.chat.message.formatted_chat_message import FormattedAttachmentPart, FormattedChatMessage, FormattedTextPart
 from features.chat.whatsapp.model.response import MessageResponse
 from features.integrations.integration_config import THE_AGENT
 from util import log
@@ -42,7 +43,8 @@ class WhatsAppBotSDK:
             image_url = public_url,
             caption = caption,
         )
-        message = self.__store_api_response_as_message(sent_message, text = caption or "", chat_id = chat_config.chat_id)
+        content = self.__media_message_content(attachment, caption)
+        message = self.__store_api_response_as_message(sent_message, text = content.to_text(), chat_id = chat_config.chat_id)
         # we should now quickly update the attachment record with the new ID
         self.__di.chat_attachment_service.save(replace(attachment, message_id = message.message_id))
         return message
@@ -61,7 +63,8 @@ class WhatsAppBotSDK:
             document_url = public_url,
             caption = caption,
         )
-        message = self.__store_api_response_as_message(sent_message, text = caption or "", chat_id = chat_config.chat_id)
+        content = self.__media_message_content(attachment, caption)
+        message = self.__store_api_response_as_message(sent_message, text = content.to_text(), chat_id = chat_config.chat_id)
         # we should now quickly update the attachment record with the new ID
         self.__di.chat_attachment_service.save(replace(attachment, message_id = message.message_id))
         return message
@@ -102,3 +105,15 @@ class WhatsAppBotSDK:
             text = text,
         )
         return self.__di.chat_message_repo.save(message)
+
+    # noinspection PyMethodMayBeStatic
+    def __media_message_content(
+        self,
+        attachment: ChatAttachment,
+        caption: str | None,
+    ) -> FormattedChatMessage:
+        parts = []
+        if caption:
+            parts.append(FormattedTextPart(text = caption))
+        parts.append(FormattedAttachmentPart.from_attachments([attachment]))
+        return FormattedChatMessage(parts = parts)

--- a/src/features/chat/whatsapp/whatsapp_data_resolver.py
+++ b/src/features/chat/whatsapp/whatsapp_data_resolver.py
@@ -1,7 +1,5 @@
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from uuid import UUID
-
-from pydantic import BaseModel
 
 from db.model.chat_config import ChatConfigDB
 from di.di import DI
@@ -13,6 +11,7 @@ from features.chat.message.chat_message import ChatMessage
 from features.chat.message.chat_message_mapper import apply_remote_data as apply_remote_data_message
 from features.chat.message.chat_message_mapper import from_remote_data as from_remote_data_message
 from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
+from features.chat.message.formatted_chat_message import FormattedChatMessage
 from features.chat.whatsapp.whatsapp_domain_mapper import WhatsAppDomainMapper
 from features.integrations.integrations import is_the_agent
 from features.users.user import User
@@ -31,7 +30,8 @@ class WhatsAppDataResolver:
     If needed, this resolver will fetch more data from the API or the database.
     """
 
-    class Result(BaseModel):
+    @dataclass(kw_only = True)
+    class Result:
         chat: ChatConfig
         author: User | None
         message: ChatMessage
@@ -59,41 +59,44 @@ class WhatsAppDataResolver:
         # ensure a membership row exists for real users (skip the agent itself)
         if resolved_author and not is_author_the_agent:
             self.__di.chat_membership_service.sync(resolved_author, resolved_chat_config)
-        # Handle replied-to message (WhatsApp doesn't provide content, so we fetch from DB)
-        remote_message = mapping_result.message
-        if mapping_result.replied_to_message_id:
-            replied_message = self.__di.chat_message_repo.get(
-                resolved_chat_config.chat_id,
-                mapping_result.replied_to_message_id,
+        should_resolve_attachments = bool(mapping_result.attachments and not is_author_the_agent)
+        if should_resolve_attachments:
+            initial_message = self.__resolve_message_content(
+                mapping_result = mapping_result,
+                chat_id = resolved_chat_config.chat_id,
+                attachments = [],
+                should_replace_attachments = True,
             )
-            if replied_message:
-                quoted_text = self.__format_quoted_message(replied_message.text)
-                remote_message = ChatMessageRemoteData(
-                    message_id = remote_message.message_id,
-                    sent_at = remote_message.sent_at,
-                    text = f"{quoted_text}\n\n{remote_message.text}",
+            self.resolve_chat_message(
+                mapped_data = initial_message,
+                chat_id = resolved_chat_config.chat_id,
+                author_id = resolved_author.id if resolved_author else None,
+            )
+        resolved_attachments: list[ChatAttachment] = []
+        # skip attachment resolution for the agent's own messages — the SDK already archives outbound media
+        if should_resolve_attachments:
+            if not resolved_author or not resolved_author.id:
+                raise InternalError("WhatsApp attachment cannot be resolved without a message author", PLATFORM_MAPPING_FAILED)
+            resolved_attachments = [
+                self.resolve_chat_attachment(
+                    attachment,
+                    resolved_chat_config.chat_id,
+                    resolved_author.id,
                 )
-            else:
-                log.w(f"  Replied-to message '{mapping_result.replied_to_message_id}' not found in DB")
+                for attachment in mapping_result.attachments
+            ]
+        remote_message = self.__resolve_message_content(
+            mapping_result = mapping_result,
+            chat_id = resolved_chat_config.chat_id,
+            attachments = resolved_attachments,
+            should_replace_attachments = should_resolve_attachments,
+        )
         # we need to set the resolved chat's UUID to the message
         resolved_chat_message = self.resolve_chat_message(
             mapped_data = remote_message,
             chat_id = resolved_chat_config.chat_id,
             author_id = resolved_author.id if resolved_author else None,
         )
-        resolved_attachments: list[ChatAttachment] = []
-        # skip attachment resolution for the agent's own messages — the SDK already archives outbound media
-        if mapping_result.attachments and not is_author_the_agent:
-            if not resolved_author or not resolved_author.id:
-                raise InternalError("WhatsApp attachment cannot be resolved without a message author", PLATFORM_MAPPING_FAILED)
-            resolved_attachments = [
-                self.resolve_chat_attachment(
-                    attachment,
-                    resolved_chat_message.chat_id,
-                    resolved_author.id,
-                )
-                for attachment in mapping_result.attachments
-            ]
         return WhatsAppDataResolver.Result(
             chat = resolved_chat_config,
             author = resolved_author,
@@ -142,8 +145,30 @@ class WhatsAppDataResolver:
             raise ExternalServiceError(f"Could not download WhatsApp media '{attachment.external_id}'", MEDIA_DOWNLOAD_FAILED)
         return self.__di.chat_attachment_service.save(attachment, content)
 
-    # noinspection PyMethodMayBeStatic
-    def __format_quoted_message(self, text: str) -> str:
-        all_lines = text.split("\n")
-        prefixed_lines = [f">>>> {line}" for line in all_lines]
-        return "\n".join(prefixed_lines)
+    def __resolve_message_content(
+        self,
+        mapping_result: WhatsAppDomainMapper.Result,
+        chat_id: UUID,
+        attachments: list[ChatAttachment],
+        should_replace_attachments: bool,
+    ) -> ChatMessageRemoteData:
+        formatted_message = mapping_result.formatted_message or FormattedChatMessage.from_text(mapping_result.message.text)
+        if should_replace_attachments:
+            formatted_message = formatted_message.with_attachments(attachments)
+        if mapping_result.replied_to_message_id:
+            replied_message = self.__di.chat_message_repo.get(chat_id, mapping_result.replied_to_message_id)
+            if replied_message:
+                replied_attachments = self.__di.chat_attachment_repo.get_all_by_message(
+                    replied_message.chat_id,
+                    replied_message.message_id,
+                )
+                formatted_message = formatted_message.prepend_quote(
+                    FormattedChatMessage.from_text(replied_message.text, replied_attachments),
+                )
+            else:
+                log.w(f"  Replied-to message '{mapping_result.replied_to_message_id}' not found in DB")
+        return ChatMessageRemoteData(
+            message_id = mapping_result.message.message_id,
+            sent_at = mapping_result.message.sent_at,
+            text = formatted_message.to_text(),
+        )

--- a/src/features/chat/whatsapp/whatsapp_domain_mapper.py
+++ b/src/features/chat/whatsapp/whatsapp_domain_mapper.py
@@ -1,26 +1,31 @@
+from dataclasses import dataclass
 from datetime import datetime
 
-from pydantic import BaseModel, SecretStr
+from pydantic import SecretStr
 
 from db.model.chat_config import ChatConfigDB
 from features.chat.attachment.chat_attachment_remote_data import ChatAttachmentRemoteData
 from features.chat.config.chat_config_remote_data import ChatConfigRemoteData
 from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
-from features.chat.whatsapp.model.message import Message
+from features.chat.message.formatted_chat_message import FormattedAttachmentPart, FormattedChatMessage, FormattedTextPart
+from features.chat.whatsapp.model.message import Message as WhatsAppMessage
 from features.chat.whatsapp.model.update import Update
 from features.chat.whatsapp.model.value import Value
 from features.users.user_remote_data import UserRemoteData
 from util import log
-from util.functions import generate_deterministic_short_uuid, normalize_phone_number
+from util.functions import normalize_phone_number
 
 
 class WhatsAppDomainMapper:
 
-    class Result(BaseModel):
+    @dataclass(kw_only = True)
+    class Result:
+
         chat: ChatConfigRemoteData
         author: UserRemoteData | None
         message: ChatMessageRemoteData
         attachments: list[ChatAttachmentRemoteData]
+        formatted_message: FormattedChatMessage | None = None
         replied_to_message_id: str | None = None
 
     def map_update(self, update: Update) -> list[Result]:
@@ -45,14 +50,16 @@ class WhatsAppDomainMapper:
                 for message in value.messages:
                     result_chat = self.map_chat(message, value)
                     result_author = self.map_author(message, value)
-                    result_message = self.map_message(message)
                     result_attachments = self.map_attachments(message)
+                    result_formatted_message = self.map_content(message, result_attachments)
+                    result_message = self.map_message(message, result_formatted_message)
                     replied_to_message_id = message.context.id if message.context else None
                     results.append(
                         WhatsAppDomainMapper.Result(
                             chat = result_chat,
                             author = result_author,
                             message = result_message,
+                            formatted_message = result_formatted_message,
                             attachments = result_attachments,
                             replied_to_message_id = replied_to_message_id,
                         ),
@@ -61,16 +68,21 @@ class WhatsAppDomainMapper:
             log.w(f"  No messages found in update: {update}")
         return results
 
-    def map_message(self, message: Message) -> ChatMessageRemoteData:
+    def map_message(
+        self,
+        message: WhatsAppMessage,
+        formatted_message: FormattedChatMessage | None = None,
+    ) -> ChatMessageRemoteData:
         log.t(f"  Mapping message: {message}")
+        formatted_message = formatted_message or self.map_content(message)
         return ChatMessageRemoteData(
             message_id = message.id,
             sent_at = datetime.fromtimestamp(int(message.timestamp)),
-            text = self.map_text(message),
+            text = formatted_message.to_text(),
         )
 
     # noinspection PyMethodMayBeStatic
-    def map_author(self, message: Message, value: Value) -> UserRemoteData | None:
+    def map_author(self, message: WhatsAppMessage, value: Value) -> UserRemoteData | None:
         full_name: str | None = None
         wa_id: str
         if value.contacts:
@@ -89,10 +101,14 @@ class WhatsAppDomainMapper:
             whatsapp_phone_number = phone_number,
         )
 
-    def map_text(self, message: Message) -> str:
+    def map_content(
+        self,
+        message: WhatsAppMessage,
+        attachments: list[ChatAttachmentRemoteData] | None = None,
+    ) -> FormattedChatMessage:
         parts = []
         if message.text and message.text.body:
-            parts.append(message.text.body)
+            parts.append(FormattedTextPart(text = message.text.body))
         for media in [
             message.image,
             message.video,
@@ -100,14 +116,14 @@ class WhatsAppDomainMapper:
             message.document,
         ]:
             if media and media.caption:
-                parts.append(media.caption)
-        attachments_as_text = self.map_attachments_as_text(message)
-        if attachments_as_text:
-            parts.append(f"📎 {attachments_as_text}")
+                parts.append(FormattedTextPart(text = media.caption))
+        attachments = attachments if attachments is not None else self.map_attachments(message)
+        if attachments:
+            parts.append(FormattedAttachmentPart.from_remote_data(attachments))
         log.t(f"  Mapping message text: {parts}")
-        return "\n\n".join(parts)
+        return FormattedChatMessage(parts = parts)
 
-    def map_chat(self, message: Message, value: Value) -> ChatConfigRemoteData:
+    def map_chat(self, message: WhatsAppMessage, value: Value) -> ChatConfigRemoteData:
         log.t(f"  Mapping chat for message: {message}")
         external_id = message.from_
         contacts = value.contacts or []
@@ -131,20 +147,7 @@ class WhatsAppDomainMapper:
             return contact_name
         return f"#{chat_id}"
 
-    def map_attachments_as_text(self, message: Message) -> str | None:
-        attachments = self.map_attachments(message)
-        if not attachments:
-            return None
-        formatted_attachments = [
-            f"{generate_deterministic_short_uuid(attachment.external_id)} ({attachment.mime_type})"
-            if attachment.mime_type
-            else generate_deterministic_short_uuid(attachment.external_id)
-            for attachment in attachments
-        ]
-        log.t(f"  Mapping attachments: {formatted_attachments}")
-        return f"[ {', '.join(formatted_attachments)} ]"
-
-    def map_attachments(self, message: Message) -> list[ChatAttachmentRemoteData]:
+    def map_attachments(self, message: WhatsAppMessage) -> list[ChatAttachmentRemoteData]:
         attachments: list[ChatAttachmentRemoteData] = []
         for media_type, media in [
             ("audio", message.audio),

--- a/test/features/chat/message/test_formatted_chat_message.py
+++ b/test/features/chat/message/test_formatted_chat_message.py
@@ -1,0 +1,123 @@
+import unittest
+from uuid import UUID
+
+from features.chat.attachment.chat_attachment import ChatAttachment
+from features.chat.attachment.chat_attachment_remote_data import ChatAttachmentRemoteData
+from features.chat.message.formatted_chat_message import (
+    ATTACHMENT_PLACEHOLDER_REGEX,
+    FormattedAttachmentPart,
+    FormattedAttachmentReference,
+    FormattedChatMessage,
+    FormattedQuotePart,
+    FormattedTextPart,
+)
+from util.functions import generate_deterministic_short_uuid
+
+
+class FormattedChatMessageTest(unittest.TestCase):
+
+    def test_to_text_joins_non_empty_parts(self):
+        message = FormattedChatMessage(parts = [
+            FormattedTextPart(text = "First"),
+            FormattedTextPart(text = None),
+            FormattedTextPart(text = "Second"),
+        ])
+
+        result = message.to_text()
+
+        self.assertEqual(result, "First\n\nSecond")
+
+    def test_attachment_reference_from_attachment(self):
+        attachment = ChatAttachment(
+            id = "local123",
+            chat_id = UUID(int = 1),
+            uploader_user_id = UUID(int = 2),
+            mime_type = "image/png",
+        )
+
+        result = FormattedAttachmentReference.from_attachment(attachment)
+
+        self.assertEqual(result.to_text(), "local123 (image/png)")
+
+    def test_attachment_reference_from_remote_data(self):
+        attachment = ChatAttachmentRemoteData(
+            external_id = "remote123",
+            message_id = "m1",
+            mime_type = "image/jpeg",
+        )
+
+        result = FormattedAttachmentReference.from_remote_data(attachment)
+
+        self.assertEqual(result.to_text(), f"{generate_deterministic_short_uuid('remote123')} (image/jpeg)")
+
+    def test_attachment_part_formats_multiple_attachments(self):
+        result = FormattedAttachmentPart(attachments = [
+            FormattedAttachmentReference(id = "a1", mime_type = "image/png"),
+            FormattedAttachmentReference(id = "a2"),
+        ]).to_text()
+
+        self.assertEqual(result, "📎 [ a1 (image/png), a2 ]")
+
+    def test_attachment_placeholder_regex_matches_formatted_part(self):
+        text = "📎 [ a1 (image/png), a2 ]"
+
+        result = ATTACHMENT_PLACEHOLDER_REGEX.fullmatch(text)
+
+        self.assertIsNotNone(result)
+
+    def test_quote_part_formats_quote_depth(self):
+        quote = FormattedQuotePart(
+            message = FormattedChatMessage(parts = [FormattedTextPart(text = "Quoted")]),
+        )
+
+        result = quote.to_text()
+
+        self.assertEqual(result, ">> Quoted")
+
+    def test_from_text_replaces_existing_attachment_marker(self):
+        attachment = ChatAttachment(
+            id = "local123",
+            chat_id = UUID(int = 1),
+            uploader_user_id = UUID(int = 2),
+            mime_type = "image/png",
+        )
+
+        result = FormattedChatMessage.from_text(
+            "Caption\n\n📎 [ remote123 ]",
+            [attachment],
+        )
+
+        self.assertEqual(result.to_text(), "Caption\n\n📎 [ local123 (image/png) ]")
+
+    def test_with_attachments_replaces_existing_attachment_part(self):
+        old_attachment = ChatAttachment(
+            id = "old123",
+            chat_id = UUID(int = 1),
+            uploader_user_id = UUID(int = 2),
+        )
+        new_attachment = ChatAttachment(
+            id = "new123",
+            chat_id = UUID(int = 1),
+            uploader_user_id = UUID(int = 2),
+        )
+        message = FormattedChatMessage(parts = [
+            FormattedTextPart(text = "Caption"),
+            FormattedAttachmentPart.from_attachments([old_attachment]),
+        ])
+
+        result = message.with_attachments([new_attachment])
+
+        self.assertEqual(result.to_text(), "Caption\n\n📎 [ new123 ]")
+
+    def test_prepend_quote_prefixes_all_lines(self):
+        message = FormattedChatMessage(parts = [
+            FormattedTextPart(text = "Current"),
+        ])
+        quote = FormattedChatMessage(parts = [
+            FormattedTextPart(text = "Line one\nLine two"),
+            FormattedAttachmentPart(attachments = [FormattedAttachmentReference(id = "local123")]),
+        ])
+
+        result = message.prepend_quote(quote)
+
+        self.assertEqual(result.to_text(), ">>>> Line one\n>>>> Line two\n\n>>>> 📎 [ local123 ]\n\nCurrent")

--- a/test/features/chat/telegram/sdk/test_telegram_bot_sdk.py
+++ b/test/features/chat/telegram/sdk/test_telegram_bot_sdk.py
@@ -4,9 +4,18 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 from uuid import UUID
 
+from db.model.chat_config import ChatConfigDB
 from di.di import DI
 from features.chat.attachment.chat_attachment import ChatAttachment
+from features.chat.config.chat_config_remote_data import ChatConfigRemoteData
 from features.chat.message.chat_message import ChatMessage
+from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
+from features.chat.message.formatted_chat_message import (
+    FormattedAttachmentPart,
+    FormattedAttachmentReference,
+    FormattedChatMessage,
+    FormattedTextPart,
+)
 from features.chat.telegram.sdk.telegram_bot_api import TelegramBotAPI
 from features.chat.telegram.sdk.telegram_bot_sdk import TelegramBotSDK
 from features.chat.telegram.telegram_data_resolver import TelegramDataResolver
@@ -36,6 +45,9 @@ class TelegramBotSDKTest(unittest.TestCase):
         self.mock_chat_attachment_service.save.side_effect = self.__save_attachment
         self.mock_chat_attachment_service.create_public_url.return_value = SimpleNamespace(url = self.public_url)
         self.mock_di.chat_attachment_service = self.mock_chat_attachment_service
+        # noinspection PyPropertyAccess
+        self.mock_di.chat_message_repo = Mock()
+        self.mock_di.chat_message_repo.save.side_effect = lambda message: message
 
         self.sdk = TelegramBotSDK(self.mock_di)
 
@@ -96,12 +108,39 @@ class TelegramBotSDKTest(unittest.TestCase):
     @patch.object(TelegramDomainMapper, "map_update")
     def test_send_photo(self, mock_map_update):
         caption = "test photo"
-        attachment = ChatAttachment(chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
-        expected_message = Mock(spec = ChatMessage, message_id = self.message_id)
-        mock_map_update.return_value = Mock(spec = TelegramDomainMapper.Result)
+        attachment = ChatAttachment(
+            id = "local123",
+            chat_id = self.chat_uuid,
+            uploader_user_id = self.mock_di.invoker.id,
+            mime_type = "image/png",
+        )
+        stored_message = ChatMessage(
+            chat_id = self.chat_uuid,
+            message_id = self.message_id,
+            text = "test photo\n\n📎 [ remote123 ]",
+        )
+        self.mock_di.telegram_domain_mapper.map_update.return_value = TelegramDomainMapper.Result(
+            chat = ChatConfigRemoteData(
+                external_id = self.chat_id,
+                title = "Chat Title",
+                is_private = True,
+                chat_type = ChatConfigDB.ChatType.telegram,
+            ),
+            author = None,
+            message = ChatMessageRemoteData(
+                message_id = self.message_id,
+                sent_at = stored_message.sent_at,
+                text = "test photo\n\n📎 [ remote123 ]",
+            ),
+            formatted_message = FormattedChatMessage(parts = [
+                FormattedTextPart(text = "test photo"),
+                FormattedAttachmentPart(attachments = [FormattedAttachmentReference(id = "remote123")]),
+            ]),
+            attachments = [],
+        )
         self.mock_di.telegram_data_resolver.resolve.return_value = Mock(
             spec = TelegramDataResolver.Result,
-            message = expected_message,
+            message = stored_message,
             attachments = [],
         )
 
@@ -124,17 +163,45 @@ class TelegramBotSDKTest(unittest.TestCase):
         patched_attachment = self.mock_chat_attachment_service.save.call_args.args[0]
         self.assertEqual(patched_attachment.id, attachment.id)
         self.assertEqual(patched_attachment.message_id, self.message_id)
-        self.assertEqual(result, expected_message)
+        resolved_mapping_result = self.mock_di.telegram_data_resolver.resolve.call_args.args[0]
+        self.assertEqual(resolved_mapping_result.message.text, "test photo\n\n📎 [ local123 (image/png) ]")
+        self.assertEqual(result, stored_message)
 
     @patch.object(TelegramDomainMapper, "map_update")
     def test_send_document(self, mock_map_update):
         caption = "test document"
-        attachment = ChatAttachment(chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
-        expected_message = Mock(spec = ChatMessage, message_id = self.message_id)
-        mock_map_update.return_value = Mock(spec = TelegramDomainMapper.Result)
+        attachment = ChatAttachment(
+            id = "local456",
+            chat_id = self.chat_uuid,
+            uploader_user_id = self.mock_di.invoker.id,
+        )
+        stored_message = ChatMessage(
+            chat_id = self.chat_uuid,
+            message_id = self.message_id,
+            text = "test document\n\n📎 [ remote456 ]",
+        )
+        self.mock_di.telegram_domain_mapper.map_update.return_value = TelegramDomainMapper.Result(
+            chat = ChatConfigRemoteData(
+                external_id = self.chat_id,
+                title = "Chat Title",
+                is_private = True,
+                chat_type = ChatConfigDB.ChatType.telegram,
+            ),
+            author = None,
+            message = ChatMessageRemoteData(
+                message_id = self.message_id,
+                sent_at = stored_message.sent_at,
+                text = "test document\n\n📎 [ remote456 ]",
+            ),
+            formatted_message = FormattedChatMessage(parts = [
+                FormattedTextPart(text = "test document"),
+                FormattedAttachmentPart(attachments = [FormattedAttachmentReference(id = "remote456")]),
+            ]),
+            attachments = [],
+        )
         self.mock_di.telegram_data_resolver.resolve.return_value = Mock(
             spec = TelegramDataResolver.Result,
-            message = expected_message,
+            message = stored_message,
             attachments = [],
         )
 
@@ -158,7 +225,9 @@ class TelegramBotSDKTest(unittest.TestCase):
         patched_attachment = self.mock_chat_attachment_service.save.call_args.args[0]
         self.assertEqual(patched_attachment.id, attachment.id)
         self.assertEqual(patched_attachment.message_id, self.message_id)
-        self.assertEqual(result, expected_message)
+        resolved_mapping_result = self.mock_di.telegram_data_resolver.resolve.call_args.args[0]
+        self.assertEqual(resolved_mapping_result.message.text, "test document\n\n📎 [ local456 ]")
+        self.assertEqual(result, stored_message)
 
     def test_set_status_typing(self):
         self.sdk.set_status_typing(self.chat_id)

--- a/test/features/chat/telegram/test_telegram_data_resolver.py
+++ b/test/features/chat/telegram/test_telegram_data_resolver.py
@@ -213,6 +213,56 @@ class TelegramDataResolverTest(unittest.TestCase):
         self.assertEqual(result.attachments[0].uploader_user_id, result.author.id)
         self.mock_di.chat_membership_service.sync.assert_called_once()
 
+    def test_resolve_with_reply_uses_local_attachment_id(self):
+        chat = self.sql.chat_config_repo().save(
+            ChatConfig(external_id = "c1", chat_type = ChatConfigDB.ChatType.telegram),
+        )
+        uploader = self.sql.user_repo().save(User(full_name = "Agent", telegram_user_id = 123))
+        self.sql.chat_message_repo().save(
+            ChatMessage(
+                chat_id = chat.chat_id,
+                message_id = "old-message",
+                text = "Original caption\n\n📎 [ remote123 ]",
+            ),
+        )
+        self.sql.chat_attachment_repo().save(
+            ChatAttachment(
+                id = "local123",
+                chat_id = chat.chat_id,
+                uploader_user_id = uploader.id,
+                message_id = "old-message",
+                mime_type = "image/png",
+            ),
+        )
+        mapping_result = TelegramDomainMapper.Result(
+            chat = ChatConfigRemoteData(
+                external_id = "c1",
+                title = "Chat Title",
+                is_private = True,
+                chat_type = ChatConfigDB.ChatType.telegram,
+            ),
+            author = UserRemoteData(
+                telegram_username = "username",
+                telegram_chat_id = "c1",
+                telegram_user_id = 1,
+                full_name = "New User",
+            ),
+            message = ChatMessageRemoteData(
+                message_id = "new-message",
+                sent_at = datetime.now(),
+                text = "Please use this",
+            ),
+            attachments = [],
+            replied_to_message_id = "old-message",
+        )
+
+        result = self.resolver.resolve(mapping_result)
+
+        self.assertIn(">>>> Original caption", result.message.text)
+        self.assertIn(">>>> 📎 [ local123 (image/png) ]", result.message.text)
+        self.assertIn("Please use this", result.message.text)
+        self.assertNotIn("remote123", result.message.text)
+
     def test_resolve_author_none(self):
         result = self.resolver.resolve_author(None)
         self.assertIsNone(result)

--- a/test/features/chat/telegram/test_telegram_domain_mapper.py
+++ b/test/features/chat/telegram/test_telegram_domain_mapper.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from db.model.chat_config import ChatConfigDB
 from features.chat.message.chat_message_remote_data import ChatMessageRemoteData
+from features.chat.message.formatted_chat_message import FormattedQuotePart
 from features.chat.telegram.model.attachment.audio import Audio
 from features.chat.telegram.model.attachment.document import Document
 from features.chat.telegram.model.attachment.file import File
@@ -78,6 +79,29 @@ class TelegramDomainMapperTest(unittest.TestCase):
 
         self.assertIsNone(result)
 
+    def test_map_update_with_reply(self):
+        update = Update(
+            update_id = 1,
+            message = Message(
+                chat = Chat(id = 10, type = "private"),
+                message_id = 100,
+                date = int(datetime.now().timestamp()),
+                text = "This is a test message",
+                reply_to_message = Message(
+                    chat = Chat(id = 10, type = "private"),
+                    message_id = 99,
+                    date = int(datetime.now().timestamp()),
+                    text = "This is a reply message",
+                ),
+            ),
+        )
+
+        result = self.mapper.map_update(update)
+
+        assert result is not None
+        self.assertEqual(result.replied_to_message_id, "99")
+        self.assertEqual(result.message.text, "This is a test message")
+
     def test_map_message_filled(self):
         # 'from' is a reserved keyword in Python, so we use a workaround to access it
         # noinspection PyArgumentList
@@ -151,42 +175,7 @@ class TelegramDomainMapperTest(unittest.TestCase):
 
         self.assertIsNone(result)
 
-    def test_map_text_as_reply_filled(self):
-        # 'from' is a reserved keyword in Python, so we use a workaround to access it
-        # noinspection PyArgumentList
-        message = Message(
-            chat = Chat(id = 10, type = "private"),
-            message_id = 100,
-            date = int(datetime.now().timestamp()),
-            text = "This is a test message",
-            caption = "This is a caption",
-            audio = Audio(file_id = "a1", file_unique_id = "a", mime_type = "audio/mpeg"),
-        )
-
-        result = self.mapper.map_text_as_reply(message)
-
-        # Verify format with dynamic short ID
-        lines = result.split("\n\n")
-        self.assertEqual(lines[0], ">>>> This is a caption")
-        self.assertEqual(lines[1], ">>>> This is a test message")
-        # Check attachment line format: ">>>> 📎 [ shortid (audio/mpeg) ]"
-        attachment_pattern = r">>>> 📎 \[ [a-f0-9]{8} \(audio/mpeg\) \]"
-        self.assertTrue(re.match(attachment_pattern, lines[2]), f"Attachment line '{lines[2]}' doesn't match expected format")
-
-    def test_map_text_as_reply_empty(self):
-        # 'from' is a reserved keyword in Python, so we use a workaround to access it
-        # noinspection PyArgumentList
-        message = Message(
-            chat = Chat(id = 10, type = "private"),
-            message_id = 100,
-            date = int(datetime.now().timestamp()),
-        )
-
-        result = self.mapper.map_text_as_reply(message)
-
-        self.assertEqual(result, "")
-
-    def test_map_text_filled(self):
+    def test_map_content_filled(self):
         # 'from' is a reserved keyword in Python, so we use a workaround to access it
         # noinspection PyArgumentList
         message = Message(
@@ -205,19 +194,20 @@ class TelegramDomainMapperTest(unittest.TestCase):
             voice = Voice(file_id = "v4", file_unique_id = "v", file_size = 4, mime_type = "audio/ogg"),
         )
 
-        result = self.mapper.map_text(message)
+        content = self.mapper.map_content(message)
+        result = content.to_text()
 
         # Verify format with dynamic short ID
+        self.assertIsInstance(content.parts[0], FormattedQuotePart)
         lines = result.split("\n\n")
-        self.assertEqual(lines[0], ">>>> This is a reply message")
-        self.assertEqual(lines[1], ">> This is a quote")
-        self.assertEqual(lines[2], "This is a caption")
-        self.assertEqual(lines[3], "This is a test message")
+        self.assertEqual(lines[0], ">> This is a quote")
+        self.assertEqual(lines[1], "This is a caption")
+        self.assertEqual(lines[2], "This is a test message")
         # Check attachment line format: "📎 [ shortid (audio/ogg) ]"
         attachment_pattern = r"📎 \[ [a-f0-9]{8} \(audio/ogg\) \]"
-        self.assertTrue(re.match(attachment_pattern, lines[4]), f"Attachment line '{lines[4]}' doesn't match expected format")
+        self.assertTrue(re.match(attachment_pattern, lines[3]), f"Attachment line '{lines[3]}' doesn't match expected format")
 
-    def test_map_text_empty(self):
+    def test_map_content_empty(self):
         # 'from' is a reserved keyword in Python, so we use a workaround to access it
         # noinspection PyArgumentList
         message = Message(
@@ -226,7 +216,7 @@ class TelegramDomainMapperTest(unittest.TestCase):
             date = int(datetime.now().timestamp()),
         )
 
-        result = self.mapper.map_text(message)
+        result = self.mapper.map_content(message).to_text()
 
         self.assertEqual(result, "")
 
@@ -304,36 +294,6 @@ class TelegramDomainMapperTest(unittest.TestCase):
         )
 
         self.assertEqual(result, "#10")
-
-    def test_map_attachments_as_text_filled(self):
-        # 'from' is a reserved keyword in Python, so we use a workaround to access it
-        # noinspection PyArgumentList
-        message = Message(
-            chat = Chat(id = 10, type = "private"),
-            message_id = 100,
-            audio = Audio(file_id = "a1", file_unique_id = "a", file_size = 1, mime_type = "audio/mpeg"),
-            document = Document(file_id = "d2", file_unique_id = "d", file_size = 2),
-            date = int(datetime.now().timestamp()),
-        )
-
-        result = self.mapper.map_attachments_as_text(message)
-
-        # Verify format: [ shortid (mime), shortid ]
-        expected_pattern = r"\[ [a-f0-9]{8} \(audio/mpeg\), [a-f0-9]{8} \]"
-        self.assertTrue(re.match(expected_pattern, result), f"Result '{result}' doesn't match expected format")
-
-    def test_map_attachments_as_text_empty(self):
-        # 'from' is a reserved keyword in Python, so we use a workaround to access it
-        # noinspection PyArgumentList
-        message = Message(
-            chat = Chat(id = 10, type = "private"),
-            message_id = 100,
-            date = int(datetime.now().timestamp()),
-        )
-
-        result = self.mapper.map_attachments_as_text(message)
-
-        self.assertIsNone(result)
 
     def test_map_attachments_filled(self):
         # 'from' is a reserved keyword in Python, so we use a workaround to access it

--- a/test/features/chat/test_chat_agent.py
+++ b/test/features/chat/test_chat_agent.py
@@ -127,11 +127,8 @@ class ChatAgentTest(unittest.TestCase):
             self.chat_config.chat_id,
         )
 
-    def test_init_fetches_chat_attachments_from_repository(self):
-        self.mock_di.chat_attachment_repo.get_all_by_message.assert_called_once_with(
-            self.chat_config.chat_id,
-            "msg_123",
-        )
+    def test_init_does_not_fetch_chat_attachments_from_repository(self):
+        self.mock_di.chat_attachment_repo.get_all_by_message.assert_not_called()
 
     def test_process_commands_no_api_key(self):
         # Create bot without configured_tool
@@ -311,6 +308,65 @@ class ChatAgentTest(unittest.TestCase):
 
         result = self.agent.execute()
         self.assertEqual(result.content, "LLM response")
+
+    @patch("features.chat.chat_agent.ChatAgent.process_commands")
+    @patch("features.chat.chat_agent.ChatAgent.should_reply")
+    def test_execute_removes_attachment_placeholder_from_llm_response(self, mock_should_reply, mock_process_commands):
+        mock_should_reply.return_value = True
+        mock_process_commands.return_value = ChatAgent.CommandHandlingResult(
+            is_handled = False,
+            reply = None,
+        )
+        mock_tools_model = Mock()
+        mock_tools_model.invoke.return_value = AIMessage("Here you go\n\n📎 [ a1 (image/png) ]\n\nDone")
+        self.mock_di.llm_tool_library.bind_tools.return_value = mock_tools_model
+
+        result = self.agent.execute()
+
+        self.assertEqual(result.content, "Here you go\n\nDone")
+
+    @patch("features.chat.chat_agent.ChatAgent.process_commands")
+    @patch("features.chat.chat_agent.ChatAgent.should_reply")
+    def test_execute_removes_attachment_placeholder_only_llm_response(self, mock_should_reply, mock_process_commands):
+        mock_should_reply.return_value = True
+        mock_process_commands.return_value = ChatAgent.CommandHandlingResult(
+            is_handled = False,
+            reply = None,
+        )
+        mock_tools_model = Mock()
+        mock_tools_model.invoke.return_value = AIMessage("📎 [ a1 (image/png) ]")
+        self.mock_di.llm_tool_library.bind_tools.return_value = mock_tools_model
+
+        result = self.agent.execute()
+
+        self.assertEqual(result.content, "")
+
+    @patch("features.chat.chat_agent.ChatAgent.process_commands")
+    @patch("features.chat.chat_agent.ChatAgent.should_reply")
+    def test_execute_removes_attachment_placeholder_from_llm_content_blocks(
+        self,
+        mock_should_reply,
+        mock_process_commands,
+    ):
+        mock_should_reply.return_value = True
+        mock_process_commands.return_value = ChatAgent.CommandHandlingResult(
+            is_handled = False,
+            reply = None,
+        )
+        mock_tools_model = Mock()
+        mock_tools_model.invoke.return_value = AIMessage(content = [
+            {"type": "text", "text": "Here\n📎 [ a1 (image/png) ]"},
+            "📎 [ a2 ]",
+            {"type": "thinking", "thinking": "internal"},
+        ])
+        self.mock_di.llm_tool_library.bind_tools.return_value = mock_tools_model
+
+        result = self.agent.execute()
+
+        self.assertEqual(result.content, [
+            {"type": "text", "text": "Here"},
+            {"type": "thinking", "thinking": "internal"},
+        ])
 
     @patch("features.chat.chat_agent.ChatAgent.process_commands")
     @patch("features.chat.chat_agent.ChatAgent.should_reply")

--- a/test/features/chat/whatsapp/sdk/test_whatsapp_bot_sdk.py
+++ b/test/features/chat/whatsapp/sdk/test_whatsapp_bot_sdk.py
@@ -102,7 +102,7 @@ class WhatsAppBotSDKTest(unittest.TestCase):
 
     def test_send_photo(self):
         caption = "test photo"
-        attachment = ChatAttachment(chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
+        attachment = ChatAttachment(id = "local123", chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
 
         result = self.sdk.send_photo(
             chat_config = self.chat_config,
@@ -123,11 +123,12 @@ class WhatsAppBotSDKTest(unittest.TestCase):
         self.assertEqual(patched_attachment.message_id, self.message_id)
         self.assertIsInstance(result, ChatMessage)
         self.assertEqual(result.message_id, self.message_id)
+        self.assertEqual(result.text, "test photo\n\n📎 [ local123 ]")
         self.assertEqual(result.chat_id, self.chat_uuid)
 
     def test_send_document(self):
         caption = "test document"
-        attachment = ChatAttachment(chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
+        attachment = ChatAttachment(id = "local456", chat_id = self.chat_uuid, uploader_user_id = self.mock_di.invoker.id)
 
         result = self.sdk.send_document(
             chat_config = self.chat_config,
@@ -148,6 +149,7 @@ class WhatsAppBotSDKTest(unittest.TestCase):
         self.assertEqual(patched_attachment.message_id, self.message_id)
         self.assertIsInstance(result, ChatMessage)
         self.assertEqual(result.message_id, self.message_id)
+        self.assertEqual(result.text, "test document\n\n📎 [ local456 ]")
         self.assertEqual(result.chat_id, self.chat_uuid)
 
     def test_set_reaction(self):

--- a/test/features/chat/whatsapp/test_whatsapp_data_resolver.py
+++ b/test/features/chat/whatsapp/test_whatsapp_data_resolver.py
@@ -205,7 +205,56 @@ class WhatsAppDataResolverTest(unittest.TestCase):
         self.assertEqual(result.attachments[0].message_id, attachment_data.message_id)
         self.assertEqual(result.attachments[0].chat_id, result.chat.chat_id)
         self.assertEqual(result.attachments[0].uploader_user_id, result.author.id)
+        self.assertIn(f"📎 [ {generate_deterministic_short_uuid(attachment_data.external_id)} (image/jpeg) ]", result.message.text)
         self.mock_di.chat_membership_service.sync.assert_called_once()
+
+    def test_resolve_with_reply_uses_local_attachment_id(self):
+        chat = self.sql.chat_config_repo().save(
+            ChatConfig(external_id = "c1", chat_type = ChatConfigDB.ChatType.whatsapp),
+        )
+        uploader = self.sql.user_repo().save(User(full_name = "Agent", whatsapp_user_id = "123"))
+        self.sql.chat_message_repo().save(
+            ChatMessage(
+                chat_id = chat.chat_id,
+                message_id = "old-message",
+                text = "Original caption\n\n📎 [ remote123 ]",
+            ),
+        )
+        self.sql.chat_attachment_repo().save(
+            ChatAttachment(
+                id = "local123",
+                chat_id = chat.chat_id,
+                uploader_user_id = uploader.id,
+                message_id = "old-message",
+                mime_type = "image/png",
+            ),
+        )
+        mapping_result = WhatsAppDomainMapper.Result(
+            chat = ChatConfigRemoteData(
+                external_id = "c1",
+                title = "Chat Title",
+                is_private = True,
+                chat_type = ChatConfigDB.ChatType.whatsapp,
+            ),
+            author = UserRemoteData(
+                whatsapp_user_id = "1",
+                full_name = "New User",
+            ),
+            message = ChatMessageRemoteData(
+                message_id = "new-message",
+                sent_at = datetime.now(),
+                text = "Please use this",
+            ),
+            attachments = [],
+            replied_to_message_id = "old-message",
+        )
+
+        result = self.resolver.resolve(mapping_result)
+
+        self.assertIn(">>>> Original caption", result.message.text)
+        self.assertIn(">>>> 📎 [ local123 (image/png) ]", result.message.text)
+        self.assertIn("Please use this", result.message.text)
+        self.assertNotIn("remote123", result.message.text)
 
     def test_resolve_author_none(self):
         result = self.resolver.resolve_author(None)

--- a/test/features/chat/whatsapp/test_whatsapp_domain_mapper.py
+++ b/test/features/chat/whatsapp/test_whatsapp_domain_mapper.py
@@ -233,7 +233,7 @@ class WhatsAppDomainMapperTest(unittest.TestCase):
         self.assertTrue(result.is_private)
         self.assertEqual(result.chat_type.value, "whatsapp")
 
-    def test_map_text_filled(self):
+    def test_map_content_filled(self):
         message = Message(
             id = "100",
             **{"from": "1234567890"},
@@ -242,11 +242,11 @@ class WhatsAppDomainMapperTest(unittest.TestCase):
             text = Text(body = "Hello world"),
         )
 
-        result = self.mapper.map_text(message)
+        result = self.mapper.map_content(message).to_text()
 
         self.assertEqual(result, "Hello world")
 
-    def test_map_text_empty(self):
+    def test_map_content_empty(self):
         message = Message(
             id = "100",
             **{"from": "1234567890"},
@@ -254,7 +254,7 @@ class WhatsAppDomainMapperTest(unittest.TestCase):
             type = "text",
         )
 
-        result = self.mapper.map_text(message)
+        result = self.mapper.map_content(message).to_text()
 
         self.assertEqual(result, "")
 


### PR DESCRIPTION
v5.23.2 — The Signal Tightens Around Attachments 🕶️

**Short description:** This version sharpens how The Agent handles attachments in conversations, making message behavior more controlled, more reliable, and a little harder for chaos to slip through.

The Agent has learned a stricter new instinct around attachments in messages to users. In this release, The Agent’s attachment ban strategy was updated to better control when and how attachments are handled. That means cleaner behavior, fewer strange edge cases, and stronger guardrails where they matter most.

It’s a small release on the surface — but sometimes the quiet updates are the ones that keep the machine watching without blinking. ⚙️

### What changed
- The Agent now uses an updated strategy for restricting attachments in messages to users
- The Agent’s message handling is now more consistent around attachment-related behavior
- The Agent’s safeguards were refined to reduce unwanted attachment scenarios

More signal. Less noise. The Agent moves forward.
